### PR TITLE
KAN-126 Feat: editor 목차패널 toc(table of contents) 구현

### DIFF
--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from 'next/navigation'
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { useAtom, useSetAtom } from 'jotai'
@@ -10,6 +10,7 @@ import { isEditableAtom } from 'store/editorAtoms'
 import { productTitleAtom } from 'store/productsAtoms'
 import { HandleEditor } from 'types/common/editor'
 import { ModalHandler } from 'types/common/modalRef'
+import { TocItemType } from 'types/common/pannel'
 
 import DefaultEditor from '@components/editor/DefaultEditor'
 import Modal from '@components/modal/Modal'
@@ -18,6 +19,7 @@ import IndexPannel from '@components/pannel/IndexPannel'
 import { useGetProductDetail, useProducts } from '@hooks/index'
 
 import { addHeadingIds } from '@utils/addHeadingId'
+import { getTocFromEditor } from '@utils/getTocFromEditor'
 
 import MemoPannel from './_components/memo-pannel/MemoPannel'
 import PlannerPannel from './_components/planner-pannel/PlannerPannel'
@@ -36,14 +38,6 @@ const cx = classNames.bind(styles)
  * [ ] 자동 저장 기능
  */
 
-// mock data example
-const TABLE_OF_CONTENTS = [
-  { id: 'heading1', title: '제목 1' },
-  { id: 'heading2', title: '제목 2' },
-  { id: 'heading3', title: '제목 3' },
-  { id: 'heading4', title: '제목 4' },
-]
-
 export default function WorkSpacePage() {
   const params = useParams<{ id: string }>()
   const editorRef = useRef<HandleEditor>(null)
@@ -56,6 +50,8 @@ export default function WorkSpacePage() {
 
   const [productTitle, setProductTitle] = useAtom(productTitleAtom)
   const setIsContentEditing = useSetAtom(isEditableAtom)
+
+  const [editorIndexToc, setEditorIndexToc] = useState<TocItemType[]>([])
 
   const handleSave = async () => {
     if (editorRef.current) {
@@ -125,6 +121,12 @@ export default function WorkSpacePage() {
     if (!productDetail?.title && !productDetail?.content) {
       setIsContentEditing(true)
     }
+    // TODO(Sohyun): editor가 업데이트될 때마다 toc 업데이트 하기(editor.on and update)
+    if (productDetail?.content) {
+      const contentJSON = JSON.parse(productDetail.content)
+      const toc = getTocFromEditor(contentJSON)
+      setEditorIndexToc(toc)
+    }
   }, [productDetail, setProductTitle, setIsContentEditing])
 
   return (
@@ -138,8 +140,7 @@ export default function WorkSpacePage() {
       <div className={cx('header-space')}></div>
 
       <main className={cx('main-section')}>
-        {/* TODO ToC 데이터를 IndexPannel로 전달 */}
-        <IndexPannel toc={TABLE_OF_CONTENTS} />
+        <IndexPannel toc={editorIndexToc} />
 
         <div className={cx('index-space')}></div>
 

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -18,8 +18,7 @@ import IndexPannel from '@components/pannel/IndexPannel'
 
 import { useGetProductDetail, useProducts } from '@hooks/index'
 
-import { addHeadingIds } from '@utils/addHeadingId'
-import { getTocFromEditor } from '@utils/getTocFromEditor'
+import { addHeadingIds, getTocFromEditor } from '@utils/index'
 
 import MemoPannel from './_components/memo-pannel/MemoPannel'
 import PlannerPannel from './_components/planner-pannel/PlannerPannel'

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -34,8 +34,8 @@ const cx = classNames.bind(styles)
 /**
  * TODO 작업공간 페이지 중 에디터 관련
  * [ ] 읽기 모드일때는 툴바 활성화 X
- * [ ] 에디터 TOC
- * [ ] 자동 저장 기능
+ * [x] 에디터 TOC
+ * [ ] 자동 저장 기능 + TOC 업데이트
  */
 
 export default function WorkSpacePage() {
@@ -121,7 +121,7 @@ export default function WorkSpacePage() {
     if (!productDetail?.title && !productDetail?.content) {
       setIsContentEditing(true)
     }
-    // TODO(Sohyun): editor가 업데이트될 때마다 toc 업데이트 하기(editor.on and update)
+    // 에디터 저장한 값으로 toc 업데이트
     if (productDetail?.content) {
       const contentJSON = JSON.parse(productDetail.content)
       const toc = getTocFromEditor(contentJSON)

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from 'next/navigation'
 
 import { useCallback, useEffect, useRef } from 'react'
 
+import { Editor } from '@tiptap/react'
 import { useAtom, useSetAtom } from 'jotai'
 import { isEditableAtom } from 'store/editorAtoms'
 import { productTitleAtom } from 'store/productsAtoms'
@@ -15,6 +16,8 @@ import Modal from '@components/modal/Modal'
 import IndexPannel from '@components/pannel/IndexPannel'
 
 import { useGetProductDetail, useProducts } from '@hooks/index'
+
+import { addHeadingIds } from '@utils/addHeadingId'
 
 import MemoPannel from './_components/memo-pannel/MemoPannel'
 import PlannerPannel from './_components/planner-pannel/PlannerPannel'
@@ -56,13 +59,14 @@ export default function WorkSpacePage() {
 
   const handleSave = async () => {
     if (editorRef.current) {
-      const editor = editorRef.current.getEditor()
+      const editor = editorRef.current.getEditor() as Editor
+      const contentsWithIds = addHeadingIds(editor.getJSON()) // heading에 id속성 부여된 최종 에디터 content
 
       saveProductMutation.mutate({
         productId: params.id,
         product: {
           title: productTitle,
-          content: JSON.stringify(editor?.getJSON()),
+          content: JSON.stringify(contentsWithIds),
           isAutoSave: false,
         },
       })

--- a/src/app/components/editor/DefaultEditor.module.scss
+++ b/src/app/components/editor/DefaultEditor.module.scss
@@ -33,6 +33,10 @@
     font-size: 2.4rem;
     font-weight: 700;
     line-height: 3.6rem;
+
+    // MEMO(Sohyun): 고정된 헤더로인해 스크롤이 상단에 올라갔을 때 가려지는 문제가 있어서
+    // 뷰포트(화면에 보이는 영역)의 상단에 도달했을 때 추가적인 여백을 지정
+    scroll-margin-top: 124px;
   }
 
   blockquote {

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -17,6 +17,7 @@ import { activeMenuAtom, isEditableAtom, selectionAtom } from 'store/editorAtoms
 import { HandleEditor } from 'types/common/editor'
 
 import BlockquoteExtension from '@extensions/Blockquote'
+import HeadingExtension from '@extensions/Heading'
 import Indent from '@extensions/Indent'
 
 import PromptMenu from './PromptMenu'
@@ -47,6 +48,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
       Heading.configure({
         levels: [1],
       }),
+      HeadingExtension,
       Indent,
       Bold,
       Italic,

--- a/src/app/components/pannel/IndexPannel.module.scss
+++ b/src/app/components/pannel/IndexPannel.module.scss
@@ -32,6 +32,10 @@
     color: color.$alert-secondary-300;
     font-weight: 400;
 
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
     &:hover {
       color: color.$alert-secondary-900;
       cursor: pointer;

--- a/src/app/components/pannel/IndexPannel.tsx
+++ b/src/app/components/pannel/IndexPannel.tsx
@@ -2,6 +2,8 @@
 
 import { MouseEvent, useEffect, useState } from 'react'
 
+import { TocItemType } from 'types/common/pannel'
+
 import Pannel from '@components/pannel/Pannel'
 
 import { useCollapsed } from '@hooks/common/useCollapsed'
@@ -12,13 +14,8 @@ import styles from './IndexPannel.module.scss'
 
 const cx = classNames.bind(styles)
 
-interface TocItem {
-  id: string
-  title: string
-}
-
 interface IndexPannelProps {
-  toc: TocItem[]
+  toc: TocItemType[]
 }
 
 export default function IndexPannel({ toc }: IndexPannelProps) {

--- a/src/app/components/pannel/IndexPannel.tsx
+++ b/src/app/components/pannel/IndexPannel.tsx
@@ -36,7 +36,7 @@ export default function IndexPannel({ toc }: IndexPannelProps) {
           .filter((entry) => entry.isIntersecting)
           .sort((a, b) => {
             return (
-              // MEMO(Sohyun): 에디터 제목으로 목차 인덱스를 isIntersecting이 시에 여러 개의 요소를 감지하고 있고,
+              // MEMO(Sohyun): 에디터 제목으로 목차 인덱스를 isIntersecting할 시에 여러 개의 요소를 감지하고 있고,
               // 이 중 마지막으로 감지된 요소가 setActiveId에 들어가면서 가장 맨 마지막 제목이 활성화되는 문제가 있음.
               // 따라서, 화면 맨 위(viewport top)로부터 얼마나 떨어져 있는지를 계산하여 뷰포트에서 가장 위에 가까운 heading이 0번 인덱스로 오도록 적용
               (a.target as HTMLElement).getBoundingClientRect().top -

--- a/src/app/components/pannel/IndexPannel.tsx
+++ b/src/app/components/pannel/IndexPannel.tsx
@@ -32,14 +32,27 @@ export default function IndexPannel({ toc }: IndexPannelProps) {
     // https://developer.mozilla.org/ko/docs/Web/API/IntersectionObserver
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id)
-          }
-        })
+        const visibleHeadings = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => {
+            return (
+              // MEMO(Sohyun): 에디터 제목으로 목차 인덱스를 isIntersecting이 시에 여러 개의 요소를 감지하고 있고,
+              // 이 중 마지막으로 감지된 요소가 setActiveId에 들어가면서 가장 맨 마지막 제목이 활성화되는 문제가 있음.
+              // 따라서, 화면 맨 위(viewport top)로부터 얼마나 떨어져 있는지를 계산하여 뷰포트에서 가장 위에 가까운 heading이 0번 인덱스로 오도록 적용
+              (a.target as HTMLElement).getBoundingClientRect().top -
+              (b.target as HTMLElement).getBoundingClientRect().top
+            )
+          })
+
+        // 0번 인덱스에 해당하는 요소만 setActiveId에 들어가도록
+        if (visibleHeadings.length > 0) {
+          const topHeading = visibleHeadings[0]
+          setActiveId(topHeading.target.id)
+        }
       },
       {
-        threshold: [0.45],
+        rootMargin: `-124px 0px -40% 0px`, // 고정된 헤더 높이만큼 위로올리고, 뷰포트 하단 60% 만큼 유효한 영역으로 설정
+        threshold: [0], // 요소가 1픽셀이라도 화면에 보이면 감지
       },
     )
 

--- a/src/app/extensions/Heading.ts
+++ b/src/app/extensions/Heading.ts
@@ -1,0 +1,23 @@
+import { Extension } from '@tiptap/core'
+
+// editor heading에 id 속성을 추가하기 위해 만든 extension
+const HeadingIdExtension = Extension.create({
+  name: 'heading-id-extension',
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: ['heading'], // heading node에 해당 extension을 적용
+        attributes: {
+          id: {
+            default: null,
+            parseHTML: (element) => element.getAttribute('id'), // HTML > JSON으로 변경할때 id 추출
+            renderHTML: (attributes) => (attributes.id ? { id: attributes.id } : {}), // JSON > HTML 렌더링할 때, h1 태그에 id 적용
+          },
+        },
+      },
+    ]
+  },
+})
+
+export default HeadingIdExtension

--- a/src/app/types/common/pannel.ts
+++ b/src/app/types/common/pannel.ts
@@ -1,0 +1,4 @@
+export interface TocItemType {
+  id: string
+  title: string
+}

--- a/src/app/utils/addHeadingId.ts
+++ b/src/app/utils/addHeadingId.ts
@@ -1,0 +1,21 @@
+import { JSONContent } from '@tiptap/react'
+import { v4 as uuidv4 } from 'uuid'
+
+/**
+ * Editor의 제목(Heading)에 id 속성을 부여하는 유틸 함수
+ * @param node JSON 형식으로 변환된 Editor 콘텐츠
+ * @returns node
+ */
+export const addHeadingIds = (node: JSONContent) => {
+  if (node.content) {
+    node.content.map((node) => {
+      if (node.type === 'heading') {
+        node.attrs = {
+          ...node.attrs,
+          id: `heading-${uuidv4()}`,
+        }
+      }
+    })
+  }
+  return node
+}

--- a/src/app/utils/getTocFromEditor.ts
+++ b/src/app/utils/getTocFromEditor.ts
@@ -14,6 +14,7 @@ export const getTocFromEditor = (node: JSONContent) => {
       if (node.type === 'heading' && node.attrs?.id) {
         // 서식, 줄바꿈이 적용된 제목의 경우 content가 배열로 저장되므로 합쳐서 하나의 문자열로 저장되도록
         const title = node.content?.map((value) => value.text).join('') || ''
+        if (!title.trim()) return // 제목이 없는 경우
         toc.push({ id: node.attrs.id, title })
       }
     })

--- a/src/app/utils/getTocFromEditor.ts
+++ b/src/app/utils/getTocFromEditor.ts
@@ -1,0 +1,22 @@
+import { JSONContent } from '@tiptap/react'
+import { TocItemType } from 'types/common/pannel'
+
+/**
+ * Editor Content에서 heading을 추출해서 toc를 만드는 유틸 함수
+ * @param node JSON 형식으로 변환된 Editor 콘텐츠
+ * @returns node
+ */
+export const getTocFromEditor = (node: JSONContent) => {
+  const toc: TocItemType[] = []
+
+  if (node.content) {
+    node.content.forEach((node) => {
+      if (node.type === 'heading' && node.attrs?.id) {
+        // 서식, 줄바꿈이 적용된 제목의 경우 content가 배열로 저장되므로 합쳐서 하나의 문자열로 저장되도록
+        const title = node.content?.map((value) => value.text).join('') || ''
+        toc.push({ id: node.attrs.id, title })
+      }
+    })
+  }
+  return toc
+}

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -1,3 +1,4 @@
 // utils import
 export * from './formatDate'
 export * from './handleAxiosError'
+export * from './addHeadingId'

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -2,3 +2,4 @@
 export * from './formatDate'
 export * from './handleAxiosError'
 export * from './addHeadingId'
+export * from './getTocFromEditor'


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- [작업 공간] 페이지 <목차 패널>에 해당하는 **toc** 기능을 구현했습니다.
- 자세한 요구사항은 관련이슈 JIRA 이슈번호를 확인해 주세요.

<br />

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- close #3 
- JIRA [KAN-126](https://writelyforwriters.atlassian.net/browse/KAN-126?atlOrigin=eyJpIjoiOTM3Njk0OTZjYWExNGIwNjk0ZWNiNmExYzc2YWM0YWYiLCJwIjoiaiJ9)

<br />

> ## 변경 사항
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- 에디터 내용의 제목을 추출해서 toc 구성
- 작품을 [저장 버튼]을 눌러 저장할 때 toc에 반영되도록 적용 (*아래 추가 정보 목차 패널 기획 수정 확인)
- 앵커 링크 이동을 위해 uuid로 랜덤 id 부여
- 에디터 heading에 id라는 attribute를 부여하기 위해 extension 구현
- 에디터 뷰포트에서 가장 상단에 있는 제목을 active 하도록 적용

<br />

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
![toc-gif](https://github.com/user-attachments/assets/b9bf11d0-3e53-4c2d-b1b4-8cf71290a180)


<br />

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
### 공통 목차 패널 IntersectionObserver 로직 수정
- 기존 @HaJaehyeong 재형님께서 만들어주신 IntersectionObserver를 작업 공간 목차 패널에 적용하면서, 에디터 내용 뷰포트에서 제목이 여러개 보여질 경우 가장 상단에 있는 제목이 노출되도록 수정했습니다. 작품 플래너 페이지에서도 이상없이 동작하는 점을 확인하였는데, 확인 부탁드립니다.

### 목차 패널 기획 수정
- 작업 공간의 목차 패널은 에디터에 제목을 입력, 수정, 삭제하는 즉시 목차에 반영되는 구조에서 -> **작품을 저장할때 (자동저장, 수동저장) 목차에 반영되는 구조**로 변경할 계획입니다. 현재는 수동 저장했을 때 반영하는 작업을 완료한 상태이며, 이후 진행할 자동저장 기능에서 추가로 적용할 예정입니다. 참고 부탁드립니다. (디스코드 > 개발-전체 > 작업공간 페이지 목차패널 관련 스레드 참고)

<br />


[KAN-126]: https://writelyforwriters.atlassian.net/browse/KAN-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ