### PR TITLE
[KAN-125] Feat: 작품 자동 저장 기능 구현

### DIFF
--- a/src/app/(after-login)/workspace/[id]/_components/workspace-action-bar/WorkspaceActionBar.tsx
+++ b/src/app/(after-login)/workspace/[id]/_components/workspace-action-bar/WorkspaceActionBar.tsx
@@ -2,9 +2,9 @@
 
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react'
 
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { FormProvider, useForm } from 'react-hook-form'
-import { isEditableAtom } from 'store/editorAtoms'
+import { autoSaveMessageAtom, isEditableAtom } from 'store/editorAtoms'
 import { productTitleAtom } from 'store/productsAtoms'
 import { ModalHandler } from 'types/common/modalRef'
 
@@ -139,6 +139,8 @@ export default function WorkspaceActionBar({
     const [title, setTitle] = useState(initialTitle) // 로컬 상태 관리
     const [titleAtom, setTitleAtom] = useAtom(productTitleAtom) // 전역 상태 관리
 
+    const autoSave = useAtomValue(autoSaveMessageAtom)
+
     // 엔터키 트리거 이벤트
     const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
@@ -170,7 +172,7 @@ export default function WorkspaceActionBar({
           </span>
         )}
         {/* Note: description은 동적 렌더링 필요 */}
-        <span className={cx('description')}>저장 중</span>
+        <span className={cx('description')}>{autoSave.message}</span>
       </>
     )
   }

--- a/src/app/(after-login)/workspace/[id]/_components/workspace-action-bar/WorkspaceActionBar.tsx
+++ b/src/app/(after-login)/workspace/[id]/_components/workspace-action-bar/WorkspaceActionBar.tsx
@@ -171,8 +171,7 @@ export default function WorkspaceActionBar({
             {title}
           </span>
         )}
-        {/* Note: description은 동적 렌더링 필요 */}
-        <span className={cx('description')}>{autoSave.message}</span>
+        {isContentEditing && <span className={cx('description')}>{autoSave.message}</span>}
       </>
     )
   }

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -9,7 +9,7 @@ import { AUTO_SAVE_MESSAGE } from 'constants/workspace/message'
 import { DELAY_TIME_FOR_TEST } from 'constants/workspace/number'
 import { useAtom, useSetAtom } from 'jotai'
 import { autoSaveMessageAtom, editorContentAtom, isEditableAtom } from 'store/editorAtoms'
-import { productTitleAtom } from 'store/productsAtoms'
+import { productIdAtom, productTitleAtom } from 'store/productsAtoms'
 import { HandleEditor } from 'types/common/editor'
 import { ModalHandler } from 'types/common/modalRef'
 import { TocItemType } from 'types/common/pannel'
@@ -53,6 +53,7 @@ export default function WorkSpacePage() {
   const editorContent = editorContentAtom(params.id)
   const setEditorContent = useSetAtom(editorContent)
   const setAutoSaveMessage = useSetAtom(autoSaveMessageAtom)
+  const setProductId = useSetAtom(productIdAtom)
 
   const [editorIndexToc, setEditorIndexToc] = useState<TocItemType[]>([])
 
@@ -102,6 +103,12 @@ export default function WorkSpacePage() {
       return ''
     }
   }
+
+  useEffect(() => {
+    if (params.id) {
+      setProductId(params.id)
+    }
+  }, [params.id, setProductId])
 
   useEffect(() => {
     // 최초 렌더링 시 현재 상태 저장 (뒤로 가기 무효화용)

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -148,6 +148,7 @@ export default function WorkSpacePage() {
             editorRef={editorRef}
             contents={productDetail?.content}
             isSavedRef={isSavedRef}
+            productId={params.id}
           />
         </div>
 

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { AUTO_SAVE_MESSAGE } from 'constants/workspace/message'
-import { DELAY_TIME_FOR_TEST } from 'constants/workspace/number'
+import { DELAY_TIME } from 'constants/workspace/number'
 import { useAtom, useSetAtom } from 'jotai'
 import { autoSaveMessageAtom, editorContentAtom, isEditableAtom } from 'store/editorAtoms'
 import { productIdAtom, productTitleAtom } from 'store/productsAtoms'
@@ -166,7 +166,7 @@ export default function WorkSpacePage() {
       setTimeout(() => {
         setAutoSaveMessage({ message: AUTO_SAVE_MESSAGE.WRITING })
       }, 3000)
-    }, DELAY_TIME_FOR_TEST)
+    }, DELAY_TIME)
 
     return () => {
       clearInterval(interval)

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
-import { DELAY_TIME } from 'constants/workspace/number'
+import { DELAY_TIME_FOR_TEST } from 'constants/workspace/number'
 import { useAtom, useSetAtom } from 'jotai'
 import { editorContentAtom, isEditableAtom } from 'store/editorAtoms'
 import { productTitleAtom } from 'store/productsAtoms'
@@ -59,14 +59,19 @@ export default function WorkSpacePage() {
       const editor = editorRef.current.getEditor() as Editor
       const contentsWithIds = addHeadingIds(editor.getJSON()) // heading에 id속성 부여된 최종 에디터 content
 
-      saveProductMutation.mutate({
-        productId: params.id,
-        product: {
-          title: productTitle,
-          content: JSON.stringify(contentsWithIds),
-          isAutoSave: false,
+      saveProductMutation.mutate(
+        {
+          productId: params.id,
+          product: {
+            title: productTitle,
+            content: JSON.stringify(contentsWithIds),
+            isAutoSave: false,
+          },
         },
-      })
+        {
+          onSuccess: () => localStorage.removeItem(`workspace-${params.id}`),
+        },
+      )
     }
     isSavedRef.current = true
   }
@@ -143,7 +148,7 @@ export default function WorkSpacePage() {
       setEditorIndexToc(toc)
       // 자동 저장된 내용으로 에디터 업데이트
       editor.commands.setContent(contentsWithIds)
-    }, DELAY_TIME)
+    }, DELAY_TIME_FOR_TEST)
 
     return () => {
       clearInterval(interval)

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -140,8 +140,13 @@ export default function WorkSpacePage() {
         const contentsWithIds = addHeadingIds(editor.getJSON())
         setEditorContent(JSON.stringify(contentsWithIds))
         console.log(`5분마다 저장 완료 ✅, ${JSON.stringify(contentsWithIds)}`) // 삭제하기
+        // toc 업데이트
+        const toc = getTocFromEditor(contentsWithIds)
+        setEditorIndexToc(toc)
+        // 자동 저장된 내용으로 에디터 업데이트
+        editor.commands.setContent(contentsWithIds)
       },
-      30 * 1000, // 상수화
+      5 * 60 * 1000, // 상수화
     )
     return () => {
       clearInterval(interval)

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
+import { DELAY_TIME } from 'constants/workspace/number'
 import { useAtom, useSetAtom } from 'jotai'
 import { editorContentAtom, isEditableAtom } from 'store/editorAtoms'
 import { productTitleAtom } from 'store/productsAtoms'
@@ -33,8 +34,7 @@ const cx = classNames.bind(styles)
 /**
  * TODO 작업공간 페이지 중 에디터 관련
  * [ ] 읽기 모드일때는 툴바 활성화 X
- * [x] 에디터 TOC
- * [ ] 자동 저장 기능 + TOC 업데이트
+ * [ ] 단축키 '/'로 버블메뉴 활성화
  */
 
 export default function WorkSpacePage() {
@@ -133,21 +133,18 @@ export default function WorkSpacePage() {
   useEffect(() => {
     if (!editorRef.current) return
 
-    const interval = setInterval(
-      () => {
-        if (!editorRef.current) return
-        const editor = editorRef.current.getEditor() as Editor
-        const contentsWithIds = addHeadingIds(editor.getJSON())
-        setEditorContent(JSON.stringify(contentsWithIds))
-        console.log(`5분마다 저장 완료 ✅, ${JSON.stringify(contentsWithIds)}`) // 삭제하기
-        // toc 업데이트
-        const toc = getTocFromEditor(contentsWithIds)
-        setEditorIndexToc(toc)
-        // 자동 저장된 내용으로 에디터 업데이트
-        editor.commands.setContent(contentsWithIds)
-      },
-      5 * 60 * 1000, // 상수화
-    )
+    const interval = setInterval(() => {
+      if (!editorRef.current) return
+      const editor = editorRef.current.getEditor() as Editor
+      const contentsWithIds = addHeadingIds(editor.getJSON())
+      setEditorContent(JSON.stringify(contentsWithIds))
+      // toc 업데이트
+      const toc = getTocFromEditor(contentsWithIds)
+      setEditorIndexToc(toc)
+      // 자동 저장된 내용으로 에디터 업데이트
+      editor.commands.setContent(contentsWithIds)
+    }, DELAY_TIME)
+
     return () => {
       clearInterval(interval)
     }

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -25,8 +25,6 @@ import Toolbar from './Toolbar'
 
 import styles from './DefaultEditor.module.scss'
 
-// TODO 단축키 '/'로 버블메뉴 활성화
-
 interface DefaultEditorProps {
   editorRef: Ref<HandleEditor>
   isSavedRef: RefObject<boolean>

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -13,10 +13,8 @@ import TextAlign from '@tiptap/extension-text-align'
 import Underline from '@tiptap/extension-underline'
 import { BubbleMenu, EditorContent, useEditor } from '@tiptap/react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { activeMenuAtom, editorContentAtom, isEditableAtom, selectionAtom } from 'store/editorAtoms'
+import { activeMenuAtom, isEditableAtom, selectionAtom } from 'store/editorAtoms'
 import { HandleEditor } from 'types/common/editor'
-
-import { addHeadingIds } from '@utils/addHeadingId'
 
 import BlockquoteExtension from '@extensions/Blockquote'
 import HeadingExtension from '@extensions/Heading'
@@ -33,21 +31,12 @@ interface DefaultEditorProps {
   editorRef: Ref<HandleEditor>
   isSavedRef: RefObject<boolean>
   contents?: string
-  productId: string
 }
 
-export default function DefaultEditor({
-  editorRef,
-  isSavedRef,
-  contents,
-  productId,
-}: DefaultEditorProps) {
+export default function DefaultEditor({ editorRef, isSavedRef, contents }: DefaultEditorProps) {
   const [activeMenu, setActiveMenu] = useAtom(activeMenuAtom)
   const setSelection = useSetAtom(selectionAtom)
   const editable = useAtomValue(isEditableAtom)
-
-  const editorContent = editorContentAtom(productId)
-  const setEditorContent = useSetAtom(editorContent)
 
   const editor = useEditor({
     editable,
@@ -89,29 +78,6 @@ export default function DefaultEditor({
   const handleActiveMenu = () => {
     setActiveMenu('aiToolbar')
   }
-
-  /**
-   * TODO
-   * [x] 5분 마다 자동저장
-   * [ ] toc 반영
-   * [ ] 저장 후 로컬스토리지 제거
-   */
-  useEffect(() => {
-    if (!editor) return
-
-    const interval = setInterval(
-      () => {
-        const contentsWithIds = addHeadingIds(editor.getJSON())
-        setEditorContent(JSON.stringify(contentsWithIds))
-        console.log(`5분마다 저장 완료 ✅, ${JSON.stringify(contentsWithIds)}`) // 삭제하기
-      },
-      5 * 60 * 1000, // 상수화
-    )
-    return () => {
-      clearInterval(interval)
-    }
-    // MEMO(Sohyun): dependency array에 setEditorContent를 넣게 되면 입력중에 interval 시작, 종료가 반복되므로 제외
-  }, [editor])
 
   useEffect(() => {
     if (!editor) {

--- a/src/app/constants/workspace/message.ts
+++ b/src/app/constants/workspace/message.ts
@@ -1,0 +1,4 @@
+export const AUTO_SAVE_MESSAGE = {
+  WRITING: '5분 뒤에 자동 저장됩니다',
+  SAVING: '저장 중입니다',
+}

--- a/src/app/constants/workspace/number.ts
+++ b/src/app/constants/workspace/number.ts
@@ -1,2 +1,1 @@
 export const DELAY_TIME = 5 * 60 * 1000 // 5분
-export const DELAY_TIME_FOR_TEST = 30 * 1000 // 테스트용

--- a/src/app/constants/workspace/number.ts
+++ b/src/app/constants/workspace/number.ts
@@ -1,1 +1,2 @@
 export const DELAY_TIME = 5 * 60 * 1000 // 5분
+export const DELAY_TIME_FOR_TEST = 30 * 1000 // 테스트용

--- a/src/app/constants/workspace/number.ts
+++ b/src/app/constants/workspace/number.ts
@@ -1,0 +1,1 @@
+export const DELAY_TIME = 5 * 60 * 1000 // 5분

--- a/src/app/store/editorAtoms.ts
+++ b/src/app/store/editorAtoms.ts
@@ -1,4 +1,5 @@
 import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 
 type ToolbarType = 'defaultToolbar' | 'aiToolbar'
 
@@ -18,3 +19,9 @@ export const promptValueAtom = atom('')
 
 // 에디터 상태(읽기, 쓰기)
 export const isEditableAtom = atom(true)
+
+// 에디터 내용을 로컬스토리지에 저장하기 위한 atom
+// atomWithStorage는 기본 로컬스토리지 사용
+export const editorContentAtom = (productId: string) => {
+  return atomWithStorage(`workspace-${productId}`, '')
+}

--- a/src/app/store/editorAtoms.ts
+++ b/src/app/store/editorAtoms.ts
@@ -1,3 +1,4 @@
+import { AUTO_SAVE_MESSAGE } from 'constants/workspace/message'
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
@@ -25,3 +26,8 @@ export const isEditableAtom = atom(true)
 export const editorContentAtom = (productId: string) => {
   return atomWithStorage(`workspace-${productId}`, '')
 }
+
+// 에디터 자동 저장 관련 상태 메세지
+export const autoSaveMessageAtom = atom({
+  message: AUTO_SAVE_MESSAGE.WRITING,
+})

--- a/src/app/store/productsAtoms.ts
+++ b/src/app/store/productsAtoms.ts
@@ -1,3 +1,5 @@
 import { atom } from 'jotai'
 
 export const productTitleAtom = atom('')
+
+export const productIdAtom = atom('')


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- [작업 공간] 페이지에서 저장하기를 누르지 않아도 클라이언트에서 5분마다 자동 저장하는 기능을 구현했습니다.
- 자세한 요구사항은 [KAN-125](https://writelyforwriters.atlassian.net/browse/KAN-125?atlOrigin=eyJpIjoiMjUwY2UwZGJiMTVhNDA5MWEwYmU0NjQ0ODM5ZjEzYjAiLCJwIjoiaiJ9)를 확인해주세요.

<br />

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- [KAN-125](https://writelyforwriters.atlassian.net/browse/KAN-125?atlOrigin=eyJpIjoiMjUwY2UwZGJiMTVhNDA5MWEwYmU0NjQ0ODM5ZjEzYjAiLCJwIjoiaiJ9)

<br />

> ## 변경 사항
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- 5분 마다 에디터 내용을 로컬스토리지에 작품 id별로 저장하는 기능
- 수동 저장(버튼 저장)시 로컬스토리지 저장 내용 삭제
- 자동 저장 상태에 따른 액션바 메세지 노출
- 자동 저장 시 에디터 타이틀에 해당하는 목차 TOC(table of contents) 업데이트 기능 구현

<br />

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
### 에디터 내용(제목) 변경 > 30초 후 > toc 반영 및 앵커 기능 동작 > 액션바 상태메세지 변경
![자동저장 테스트](https://github.com/user-attachments/assets/e23aa1d7-a7db-417a-bab0-b074d6e695e6)


<br />

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
- 테스트 편의상 자동 저장 시간 간격을 5분 > 30초로 적용해 놓았습니다. 코드 리뷰 후 머지할때 5분으로 수정할 예정으로 참고 부탁드립니다.
- 시간 내어 리뷰해 주셔서 감사합니다. 파이팅!! 🥹


[KAN-125]: https://writelyforwriters.atlassian.net/browse/KAN-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-125]: https://writelyforwriters.atlassian.net/browse/KAN-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ