### PR TITLE
[KAN-137] Feat: ai-assistant 수동 수정 기능 구현

### DIFF
--- a/src/app/api/ai-assistant/aiAssistant.ts
+++ b/src/app/api/ai-assistant/aiAssistant.ts
@@ -1,0 +1,13 @@
+import { default as authInstance } from 'api/core/AuthInstance'
+
+interface PromptData {
+  productId: string
+  content: string
+  prompt: string
+}
+
+// 수동 수정
+export const postUserModify = async (promptData: PromptData) => {
+  const res = await authInstance.post('/assistant/user-modify', promptData)
+  return res.data.result
+}

--- a/src/app/components/editor/DefaultEditor.module.scss
+++ b/src/app/components/editor/DefaultEditor.module.scss
@@ -1,4 +1,6 @@
 @use '@styles/typography';
+@use '@styles/colors' as color;
+@use '@styles/mixins' as mixin;
 
 .section {
   padding: 1.6rem;
@@ -44,4 +46,40 @@
     margin: 1.6rem 0;
     padding-left: 1.6rem;
   }
+}
+
+.container {
+  position: fixed;
+  z-index: 10;
+}
+
+.prompt-menu {
+  width: 462px;
+  height: 52px;
+
+  padding: 0.8rem;
+  padding-left: 1.6rem;
+
+  @include mixin.flex(row, center, space-between);
+  gap: 1.6rem;
+
+  border-radius: 1.2rem;
+  background: color.$alert-secondary-0;
+  box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.1);
+
+  &__input {
+    flex: 1;
+    height: 100%;
+
+    @extend %typo-body-medium;
+    color: color.$core-secondary-100;
+
+    border: none;
+    outline: none;
+  }
+}
+
+.select-menu {
+  position: relative;
+  width: 200px;
 }

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -133,21 +133,19 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
   // (방법 2)
   useEffect(() => {
     if (aiResult && selectionRef.current) {
+      console.log(selectionRef.current)
+
       editor?.commands.insertContentAt(selectionRef.current, aiResult)
+      selectionRef.current = {
+        from: selectionRef.current.from,
+        to: selectionRef.current.from + aiResult.length,
+      }
+
       editor?.commands.unsetMark('highlight')
 
       setAiResult('')
     }
   }, [aiResult])
-
-  const handleOptionClick = (option: 'apply' | 'recreate' | 'cancel') => () => {
-    // TODO 선택한 텍스트 구간과 AI 선택 메뉴를 바탕으로 API 연동
-
-    switch (option) {
-      case 'cancel':
-        setActiveMenu('defaultToolbar')
-    }
-  }
 
   const handleAIPrompt = async () => {
     if (!promptValueRef || !selectionRef.current) return
@@ -169,6 +167,15 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
       }
     } catch (error) {
       console.log(error)
+    }
+  }
+
+  const handleOptionClick = (option: 'apply' | 'recreate' | 'cancel') => () => {
+    // TODO 선택한 텍스트 구간과 AI 선택 메뉴를 바탕으로 API 연동
+
+    switch (option) {
+      case 'cancel':
+        setActiveMenu('defaultToolbar')
     }
   }
 

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -115,9 +115,9 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
   const handleActiveMenu = () => {
     setActiveMenu('aiToolbar')
 
-    // --선택한 원본 text 저장
     const selection = handleTextSelection()
 
+    // --선택한 원본 text 저장
     if (editor && selection) {
       const originPhrase = editor.getText().slice(selection?.from - 1, selection?.to)
       setOriginalText(originPhrase)
@@ -177,7 +177,6 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
 
       case 'recreate':
         handleAIPrompt()
-        clearHighlight()
         onClose()
         break
 

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -141,8 +141,6 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
         to: selectionRef.current.from + aiResult.length,
       }
 
-      editor?.commands.unsetMark('highlight')
-
       setAiResult('')
     }
   }, [aiResult])
@@ -171,11 +169,31 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
   }
 
   const handleOptionClick = (option: 'apply' | 'recreate' | 'cancel') => () => {
-    // TODO 선택한 텍스트 구간과 AI 선택 메뉴를 바탕으로 API 연동
-
     switch (option) {
-      case 'cancel':
+      case 'apply':
         setActiveMenu('defaultToolbar')
+        // editor?.chain().focus().unsetMark('highlight').run()
+        onClose()
+        break
+
+      case 'recreate':
+        handleAIPrompt()
+        // editor?.chain().focus().unsetMark('highlight').run()
+        onClose()
+        break
+
+      case 'cancel':
+        if (selectionRef.current) {
+          editor?.commands.insertContentAt(selectionRef.current, originalText)
+        }
+        editor?.commands.unsetMark('highlight')
+        setActiveMenu('defaultToolbar')
+        // editor?.chain().focus().unsetMark('highlight').run()
+        onClose()
+        break
+
+      default:
+        break
     }
   }
 

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -172,13 +172,18 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
     switch (option) {
       case 'apply':
         setActiveMenu('defaultToolbar')
-        // editor?.chain().focus().unsetMark('highlight').run()
+        if (selectionRef.current) {
+          // 적용할 범위를 정확히 지정한 후 하이라이트 제거
+          editor?.chain().setTextSelection(selectionRef.current).unsetMark('highlight').run()
+        }
         onClose()
         break
 
       case 'recreate':
         handleAIPrompt()
-        // editor?.chain().focus().unsetMark('highlight').run()
+        if (selectionRef.current) {
+          editor?.chain().setTextSelection(selectionRef.current).unsetMark('highlight').run()
+        }
         onClose()
         break
 
@@ -188,7 +193,9 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
         }
         editor?.commands.unsetMark('highlight')
         setActiveMenu('defaultToolbar')
-        // editor?.chain().focus().unsetMark('highlight').run()
+        if (selectionRef.current) {
+          editor?.chain().setTextSelection(selectionRef.current).unsetMark('highlight').run()
+        }
         onClose()
         break
 

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -50,6 +50,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
   const productId = useAtomValue(productIdAtom)
 
   const selectionRef = useRef<TextSelectionRangeType | null>(null)
+  const originalSelectionRef = useRef<TextSelectionRangeType | null>(null)
   const promptValueRef = useRef('')
 
   const { isOpen, onOpen, onClose } = useCollapsed()
@@ -104,6 +105,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
 
     if (from !== to) {
       selectionRef.current = { from, to }
+      originalSelectionRef.current = { from, to }
 
       // --하이라이트
       editor?.commands.setMark('highlight', { color: '#FFFAE5' })
@@ -161,9 +163,11 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
   }
 
   // 적용할 범위를 정확히 지정한 후 하이라이트 제거
-  const clearHighlight = () => {
-    if (selectionRef.current) {
-      editor?.chain().setTextSelection(selectionRef.current).unsetMark('highlight').run()
+  const clearHighlight = (originalSelection?: TextSelectionRangeType) => {
+    const selection = originalSelection ?? selectionRef.current
+
+    if (selection) {
+      editor?.chain().setTextSelection(selection).unsetMark('highlight').run()
     }
   }
 
@@ -185,7 +189,10 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
           editor?.commands.insertContentAt(selectionRef.current, originalText)
         }
         setActiveMenu('defaultToolbar')
-        clearHighlight()
+        if (originalSelectionRef.current) {
+          clearHighlight(originalSelectionRef.current)
+          originalSelectionRef.current = null
+        }
         onClose()
         break
 

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -110,7 +110,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
     if (from !== to) {
       selectionRef.current = { from, to }
 
-      // TODO 하이라이트
+      // --하이라이트
       editor?.commands.setMark('highlight', { color: '#FFFAE5' })
       return { from, to }
     }
@@ -126,15 +126,12 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
     if (editor && selection) {
       const originPhrase = editor.getText().slice(selection?.from - 1, selection?.to)
       setOriginalText(originPhrase)
-      console.log(originPhrase)
     }
   }
 
   // (방법 2)
   useEffect(() => {
     if (aiResult && selectionRef.current) {
-      console.log(selectionRef.current)
-
       editor?.commands.insertContentAt(selectionRef.current, aiResult)
       selectionRef.current = {
         from: selectionRef.current.from,
@@ -156,10 +153,10 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
       })
 
       if (response.id) {
-        // TODO (방법 1) selection을 받아와서 대체 텍스트 삽입
+        // (방법 1) selection을 받아와서 대체 텍스트 삽입
         // editor.commands.insertContentAt(selection, response.answer)
 
-        // TODO (방법 2) ai 응답을 받아서 전역 상태 저장 > DefaultEditor에서 삽입
+        // (방법 2) ai 응답을 받아서 전역 상태 저장 > DefaultEditor에서 삽입
         setAiResult(response.answer)
         onOpen()
       }
@@ -229,10 +226,6 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
         tippyOptions={{
           duration: 100,
           maxWidth: 'none',
-          onHidden: () => {
-            // TODO remove text highlight 적용이 안되는 문제
-            // editor.chain().focus().unsetMark('highlight').run()
-          },
         }}
         // --shouldShow: 버블 메뉴 표시를 제어하는 콜백
         /* MEMO(Sohyun): DefaultEditor내부에서 editable 상태에따른 화면을 구현하고 싶었으나, 버블메뉴 shouldShow 상태 제어가 안되는 문제가 있음

--- a/src/app/components/editor/PromptMenu.module.scss
+++ b/src/app/components/editor/PromptMenu.module.scss
@@ -2,6 +2,11 @@
 @use '@styles/colors' as color;
 @use '@styles/mixins' as mixin;
 
+.container {
+  position: fixed;
+  z-index: 10;
+}
+
 .prompt-menu {
   width: 462px;
   height: 52px;

--- a/src/app/components/editor/Toolbar.tsx
+++ b/src/app/components/editor/Toolbar.tsx
@@ -203,11 +203,15 @@ export default function Toolbar({ editor, handleActiveMenu }: ToolbarProps) {
             <Image src="/icons/ai-option2.svg" alt="수동수정" width={20} height={20} />
             수동 수정
           </SelectMenu.Option>
-          <SelectMenu.Option option={{ className: styles['select-option'] }}>
+          <SelectMenu.Option
+            option={{ className: styles['select-option'], handleAction: handleActiveMenu }}
+          >
             <Image src="/icons/ai-option3.svg" alt="구간피드백" width={20} height={20} />
             구간 피드백
           </SelectMenu.Option>
-          <SelectMenu.Option option={{ className: styles['select-option'] }}>
+          <SelectMenu.Option
+            option={{ className: styles['select-option'], handleAction: handleActiveMenu }}
+          >
             <Image src="/icons/ai-option4.svg" alt="자유대화" width={20} height={20} />
             자유 대화
           </SelectMenu.Option>

--- a/src/app/store/editorAtoms.ts
+++ b/src/app/store/editorAtoms.ts
@@ -36,4 +36,4 @@ export const autoSaveMessageAtom = atom({
 export const originalPhraseAtom = atom('')
 
 // AI 수정 메세지 저장
-export const aiResultAtom = atom('대체 텍스트입니다!')
+export const aiResultAtom = atom('')

--- a/src/app/store/editorAtoms.ts
+++ b/src/app/store/editorAtoms.ts
@@ -31,3 +31,9 @@ export const editorContentAtom = (productId: string) => {
 export const autoSaveMessageAtom = atom({
   message: AUTO_SAVE_MESSAGE.WRITING,
 })
+
+// 선택한 원본 텍스트 저장
+export const originalPhraseAtom = atom('')
+
+// AI 수정 메세지 저장
+export const aiResultAtom = atom('대체 텍스트입니다!')

--- a/src/app/store/editorAtoms.ts
+++ b/src/app/store/editorAtoms.ts
@@ -1,16 +1,12 @@
 import { AUTO_SAVE_MESSAGE } from 'constants/workspace/message'
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
+import { TextSelectionRangeType } from 'types/common/editor'
 
 type ToolbarType = 'defaultToolbar' | 'aiToolbar'
 
 // 에디터 툴바 상태
 export const activeMenuAtom = atom<ToolbarType>('defaultToolbar')
-
-interface TextSelectionRangeType {
-  from: number
-  to: number
-}
 
 // 에디터 selection 상태 (드래그한 텍스트 범위) > 현재 작품 플래너에서만 사용
 export const selectionAtom = atom<TextSelectionRangeType | null>(null)

--- a/src/app/store/editorAtoms.ts
+++ b/src/app/store/editorAtoms.ts
@@ -12,7 +12,7 @@ interface TextSelectionRangeType {
   to: number
 }
 
-// 에디터 selection 상태 (드래그한 텍스트 범위)
+// 에디터 selection 상태 (드래그한 텍스트 범위) > 현재 작품 플래너에서만 사용
 export const selectionAtom = atom<TextSelectionRangeType | null>(null)
 
 // prompt 입력 값

--- a/src/app/types/common/editor.ts
+++ b/src/app/types/common/editor.ts
@@ -5,3 +5,8 @@ import { Editor } from '@tiptap/react'
 export interface HandleEditor {
   getEditor: () => Editor | null
 }
+
+export interface TextSelectionRangeType {
+  from: number
+  to: number
+}


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- AI 어시스턴트 수동 수정 기능을 구현했습니다.
- 기능 명세서는 [KAN-137](https://writelyforwriters.atlassian.net/browse/KAN-137?atlOrigin=eyJpIjoiNGNlYjQzNzQ4ZTMyNDcxOTk3MzUyNDhhOTY1NDdlYjUiLCJwIjoiaiJ9)을 참고해 주세요.

<br />

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- [KAN-137](https://writelyforwriters.atlassian.net/browse/KAN-137?atlOrigin=eyJpIjoiNGNlYjQzNzQ4ZTMyNDcxOTk3MzUyNDhhOTY1NDdlYjUiLCJwIjoiaiJ9)

<br />

> ## 변경 사항
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- 수동 수정 기능 API 연동
- 하이라이트 기능 구현
- 옵션 메뉴 (이대로 수정하기, 다시 생성하기, 취소하기) 구현

<br />

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
### 수동 수정 > 다시 생성하기 > 이대로 수정하기
![May-06-2025 20-04-33](https://github.com/user-attachments/assets/ce297d4b-30fc-41d7-a387-5e24bcb2e056)

### 수동 수정 > 다시 생성하기 > 취소하기
![May-06-2025 20-05-49](https://github.com/user-attachments/assets/5429ebfb-b2d8-4539-8263-7ee27a6ae311)

<br />

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
- 이후 작업 계획: 자동 수정 기능 > 구간 피드백 기능 > 응답에 대한 피드백 및 답변 영구 보관 기능
- 구조상 에디터 내용이 변경되면, 내부적으로 Tiptap의 transaction이 발생하면서, 버블 메뉴가 사라지고, selection은 초기화되는 문제가 있었습니다.🤯 이 문제를 해결하기 위해 기존 버블메뉴 안에 위치하던 PromptMenu 컴포넌트를 버블메뉴 외부로 분리했는데 문제는 드래그한 위치 바로 위에 버블메뉴를 스타일링하기 어려워 상단에 고정 프롬프트 input 생성했습니다. 그래서 UI가 디자인된 위치랑 다른 부분이 있는데 이 문제는 논의후 공유드리겠습니다.🥲
- 리팩토링할 부분이 많은데.. 나머지 ai-assistant 기능 완료후에 리팩토링 진행하겠습니다. 감사합니다.


[KAN-137]: https://writelyforwriters.atlassian.net/browse/KAN-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-137]: https://writelyforwriters.atlassian.net/browse/KAN-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ