### PR TITLE
KAN-110 Feat: 템플릿 저장

### DIFF
--- a/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
@@ -22,21 +22,12 @@ export default function PlannerActionBar({
   isSaved,
   onSubmit,
 }: PlannerActionBarProps) {
-  // 액션바 내 좌측 영역
   const ActionSectionContent = () => {
-    // 저장 여부 판단 state
     const [hasSaved, setHasSaved] = useState(isSaved)
-
-    // 저장 버튼 클릭 트리거 이벤트
     const handleSave = () => {
       if (!isValidFormValues) return
       onSubmit()
       setHasSaved(true)
-    }
-
-    // 삭제 버튼 클릭 트리거 이벤트
-    const handleDelete = () => {
-      alert('삭제 완료!')
     }
 
     return (
@@ -50,24 +41,16 @@ export default function PlannerActionBar({
             <TextButton size="large" onClick={() => handleSave()}>
               수정하기
             </TextButton>
-            <TextButton size="large" onClick={() => handleDelete()}>
-              삭제하기
-            </TextButton>
           </>
         )}
       </>
     )
   }
 
-  // 액션바 내 가운데 영역
   const TitleSectionContent = () => {
-    // 타이틀 수정 모드를 구분하는 state
     const [isTitleEditing, setIsTitleEditing] = useState(false)
-
-    // 타이틀명 state
     const [title, setTitle] = useState('타이틀')
 
-    // 엔터키 트리거 이벤트
     const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
         setIsTitleEditing(false)

--- a/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
@@ -106,7 +106,9 @@ export default function PlannerActionBar({
         )}
         {/* NOTE(hajae): 현재 테스트 */}
         <span className={cx('description')}>
-          {formatMillisecondToMinute(autoSaveTimer)}분 뒤에 자동 저장됩니다.
+          {autoSaveTimer > 0
+            ? `${formatMillisecondToMinute(autoSaveTimer)}분 뒤에 자동 저장됩니다.`
+            : '저장 중입니다.'}
         </span>
       </>
     )

--- a/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
@@ -32,7 +32,6 @@ export default function PlannerActionBar({
       if (!isValidFormValues) return
       onSubmit()
       setHasSaved(true)
-      alert('저장 완료!')
     }
 
     // 삭제 버튼 클릭 트리거 이벤트

--- a/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-action-bar/PlannerActionBar.tsx
@@ -10,6 +10,8 @@ import TextButton from '@components/buttons/TextButton'
 import { useProducts } from '@hooks/products/useProductsMutation'
 import { useGetProductDetail } from '@hooks/products/useProductsQueries'
 
+import { formatMillisecondToMinute } from '@utils/formatDate'
+
 import classNames from 'classnames/bind'
 
 const cx = classNames.bind(styles)
@@ -18,6 +20,7 @@ interface PlannerActionBarProps {
   productId: string
   isValidFormValues: boolean
   isSaved: boolean
+  autoSaveTimer: number
   onSubmit: () => void
 }
 
@@ -25,6 +28,7 @@ export default function PlannerActionBar({
   productId,
   isValidFormValues,
   isSaved,
+  autoSaveTimer,
   onSubmit,
 }: PlannerActionBarProps) {
   const { data: productDetail } = useGetProductDetail(productId)
@@ -100,8 +104,10 @@ export default function PlannerActionBar({
             {title}
           </span>
         )}
-        {/* Note: description은 동적 렌더링 필요 */}
-        <span className={cx('description')}>저장 중</span>
+        {/* NOTE(hajae): 현재 테스트 */}
+        <span className={cx('description')}>
+          {formatMillisecondToMinute(autoSaveTimer)}분 뒤에 자동 저장됩니다.
+        </span>
       </>
     )
   }

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
@@ -36,7 +36,7 @@ export default function PlannerCharacterFormList({
   handleRemoveCharacter,
 }: PlannerCharacterFormListProps) {
   const { isOpen, onToggle } = useCollapsed(true)
-  const { control, setValue } = useFormContext()
+  const { control } = useFormContext()
   const setCharacters = useSetAtom(plannerCharacterByIdAtom(paramsId))
 
   const watchedValues: CharacterFormValues = useWatch({
@@ -57,11 +57,6 @@ export default function PlannerCharacterFormList({
       return next
     })
   }, [watchedValues, arrayIndex, setCharacters])
-
-  // NOTE(hajae): local storage에 저장된 값으로 초기화
-  useEffect(() => {
-    setValue(`characters[${arrayIndex}]`, character)
-  }, [])
 
   const getTextFieldName = (name: string) => {
     // NOTE(hajae): customFields는 배열이나, 디자인상 Character Fields에서는 하나의 필드를 사용 중

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
@@ -25,14 +25,12 @@ const expandItems = ['intro', 'customFields']
 interface PlannerCharacterFormListProps {
   paramsId: string
   arrayIndex: number
-  character: CharacterFormValues
   handleRemoveCharacter: (index: number) => void
 }
 
 export default function PlannerCharacterFormList({
   paramsId,
   arrayIndex,
-  character,
   handleRemoveCharacter,
 }: PlannerCharacterFormListProps) {
   const { isOpen, onToggle } = useCollapsed(true)
@@ -41,7 +39,7 @@ export default function PlannerCharacterFormList({
 
   const getTextFieldName = (name: string) => {
     // NOTE(hajae): customFields는 배열이나, 디자인상 Character Fields에서는 하나의 필드를 사용 중
-    if (name === 'customFields' && character.customFields) {
+    if (name === 'customFields' && formValues.characters[arrayIndex].customFields) {
       return `characters[${arrayIndex}].customFields[0].content`
     } else {
       return `characters[${arrayIndex}].${name}`

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
@@ -1,5 +1,10 @@
+import { useEffect } from 'react'
+
 import { PLANNER_CHARACTER_ITEMS } from 'constants/planner/plannerConstants'
+import { useAtom } from 'jotai'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io'
+import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
 import { CharacterFormValues } from 'types/planner/plannerSynopsisFormValues'
 
 import FillButton from '@components/buttons/FillButton'
@@ -25,12 +30,14 @@ interface PlannerCharacterFormListProps {
 }
 
 export default function PlannerCharacterFormList({
-  // paramsId,
+  paramsId,
   arrayIndex,
   character,
   handleRemoveCharacter,
 }: PlannerCharacterFormListProps) {
   const { isOpen, onToggle } = useCollapsed(true)
+  const { control } = useFormContext()
+  const [formValues, setFormValues] = useAtom(plannerCharacterByIdAtom(paramsId))
 
   const getTextFieldName = (name: string) => {
     // NOTE(hajae): customFields는 배열이나, 디자인상 Character Fields에서는 하나의 필드를 사용 중
@@ -40,6 +47,22 @@ export default function PlannerCharacterFormList({
       return `characters[${arrayIndex}].${name}`
     }
   }
+
+  const watchedValues: CharacterFormValues = useWatch({
+    control,
+    name: `characters[${arrayIndex}]`,
+  })
+
+  // NOTE(hajae): local storage 저장
+  useEffect(() => {
+    if (!watchedValues) return
+
+    setFormValues(
+      formValues.characters.map((character, index) =>
+        index === arrayIndex ? watchedValues : character,
+      ),
+    )
+  }, [watchedValues, arrayIndex, setFormValues])
 
   return (
     <div className={cx('list')}>

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
@@ -1,10 +1,5 @@
-import { useEffect } from 'react'
-
 import { PLANNER_CHARACTER_ITEMS } from 'constants/planner/plannerConstants'
-import { useSetAtom } from 'jotai'
-import { useFormContext, useWatch } from 'react-hook-form'
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io'
-import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
 import { CharacterFormValues } from 'types/planner/plannerSynopsisFormValues'
 
 import FillButton from '@components/buttons/FillButton'
@@ -30,33 +25,12 @@ interface PlannerCharacterFormListProps {
 }
 
 export default function PlannerCharacterFormList({
-  paramsId,
+  // paramsId,
   arrayIndex,
   character,
   handleRemoveCharacter,
 }: PlannerCharacterFormListProps) {
   const { isOpen, onToggle } = useCollapsed(true)
-  const { control } = useFormContext()
-  const setCharacters = useSetAtom(plannerCharacterByIdAtom(paramsId))
-
-  const watchedValues: CharacterFormValues = useWatch({
-    control,
-    name: `characters[${arrayIndex}]`,
-  })
-
-  // NOTE(hajae): local storage 저장
-  useEffect(() => {
-    if (!watchedValues) return
-
-    setCharacters((prev) => {
-      const next = [...prev]
-      next[arrayIndex] = {
-        ...next[arrayIndex],
-        ...watchedValues,
-      }
-      return next
-    })
-  }, [watchedValues, arrayIndex, setCharacters])
 
   const getTextFieldName = (name: string) => {
     // NOTE(hajae): customFields는 배열이나, 디자인상 Character Fields에서는 하나의 필드를 사용 중

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
@@ -12,6 +12,8 @@ import TextField from '@components/text-field/TextField'
 
 import { useCollapsed } from '@hooks/common/useCollapsed'
 
+import PlannerFieldWithButton from '../planner-field-with-button/PlannerFieldWithButton'
+
 import classNames from 'classnames/bind'
 
 import styles from './PlannerCharacterFormList.module.scss'
@@ -96,18 +98,34 @@ export default function PlannerCharacterFormList({
 
       {isOpen && (
         <div className={cx('list__items')}>
-          {PLANNER_CHARACTER_ITEMS.map((item, index) => (
-            <TextField
-              key={`planner-character-item-${index}`}
-              name={getTextFieldName(item.name)}
-              label={item.label}
-              variant={expandItems.includes(item.name) ? 'expand' : undefined}
-              labelName={
-                item.name === 'customFields' ? `characters[${arrayIndex}].customFields[0].name` : ''
-              }
-              isLabelEditable={item.name === 'customFields'}
-            />
-          ))}
+          {PLANNER_CHARACTER_ITEMS.map((item, index) =>
+            // NOTE(hajae): 등장인물 이름은 삭제 불가이기 때문에 조건 추가
+            item.name !== 'name' ? (
+              <PlannerFieldWithButton
+                key={`planner-character-item-${index}`}
+                name={getTextFieldName(item.name)}
+              >
+                <TextField
+                  name={getTextFieldName(item.name)}
+                  label={item.label}
+                  variant={expandItems.includes(item.name) ? 'expand' : undefined}
+                  labelName={
+                    item.name === 'customFields'
+                      ? `characters[${arrayIndex}].customFields[0].name`
+                      : ''
+                  }
+                  isLabelEditable={item.name === 'customFields'}
+                />
+              </PlannerFieldWithButton>
+            ) : (
+              <TextField
+                key={`planner-character-item-${index}`}
+                name={getTextFieldName(item.name)}
+                label={item.label}
+                variant={expandItems.includes(item.name) ? 'expand' : undefined}
+              />
+            ),
+          )}
         </div>
       )}
     </div>

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
@@ -2,12 +2,14 @@
 
 import { useParams } from 'next/navigation'
 
+import { useEffect } from 'react'
+
 import { useAtom } from 'jotai'
+import { useFormContext } from 'react-hook-form'
 import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
 
 import FillButton from '@components/buttons/FillButton'
 
-import { CharacterFormValues } from '../../../../../types/planner/plannerSynopsisFormValues'
 import PlannerCharacterFormList from '../planner-character-form-list/PlannerCharacterFormList'
 
 import classNames from 'classnames/bind'
@@ -18,35 +20,42 @@ const cx = classNames.bind(styles)
 
 export default function PlannerCharacterForm() {
   const params = useParams<{ id: string }>()
+  const { setValue } = useFormContext()
   const [formValues, setFormValues] = useAtom(plannerCharacterByIdAtom(params.id))
 
-  const createCharacter = (): CharacterFormValues => ({
-    id: '',
-    intro: '',
-    name: '',
-    age: undefined,
-    gender: '',
-    occupation: '',
-    appearance: '',
-    personality: '',
-    relationship: '',
-    customFields: [
+  const handleAddCharacter = () => {
+    setFormValues([
+      ...formValues.characters,
       {
         id: '',
+        intro: '',
         name: '',
-        content: '',
+        age: undefined,
+        gender: '',
+        occupation: '',
+        appearance: '',
+        personality: '',
+        relationship: '',
+        customFields: [
+          {
+            id: '',
+            name: '',
+            content: '',
+          },
+        ],
       },
-    ],
-  })
-
-  const handleAddCharacter = () => {
-    setFormValues([...formValues.characters, createCharacter()])
+    ])
   }
 
   const handleRemoveCharacter = (index: number) => {
     const newCharacters = formValues.characters.filter((_, i) => i !== index)
     setFormValues(newCharacters)
   }
+
+  // NOTE(hajae): 캐릭터 추가 삭제 후, local storage만 갱신하고 있기때문에 character 수가 달라지면 set 해준다.
+  useEffect(() => {
+    setValue('characters', formValues.characters)
+  }, [setValue, formValues.characters.length])
 
   return (
     <div className={cx('character-form')} id="heading3">
@@ -62,7 +71,6 @@ export default function PlannerCharacterForm() {
           <PlannerCharacterFormList
             key={character.id ? `${character.id}-${index}` : `${index}`}
             paramsId={params.id}
-            character={character}
             arrayIndex={index}
             handleRemoveCharacter={handleRemoveCharacter}
           />

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
@@ -18,9 +18,7 @@ const cx = classNames.bind(styles)
 
 export default function PlannerCharacterForm() {
   const params = useParams<{ id: string }>()
-  const [characters, setCharacters] = useAtom<CharacterFormValues[]>(
-    plannerCharacterByIdAtom(params.id),
-  )
+  const [formValues, setFormValues] = useAtom(plannerCharacterByIdAtom(params.id))
 
   const createCharacter = (): CharacterFormValues => ({
     id: '',
@@ -42,12 +40,12 @@ export default function PlannerCharacterForm() {
   })
 
   const handleAddCharacter = () => {
-    setCharacters((prev) => [...prev, createCharacter()])
+    setFormValues([...formValues.characters, createCharacter()])
   }
 
   const handleRemoveCharacter = (index: number) => {
-    const newCharacters = characters.filter((_, i) => i !== index)
-    setCharacters(newCharacters)
+    const newCharacters = formValues.characters.filter((_, i) => i !== index)
+    setFormValues(newCharacters)
   }
 
   return (
@@ -59,8 +57,8 @@ export default function PlannerCharacterForm() {
         </FillButton>
       </div>
 
-      {characters &&
-        characters.map((character, index) => (
+      {formValues.characters &&
+        formValues.characters.map((character, index) => (
           <PlannerCharacterFormList
             key={character.id ? `${character.id}-${index}` : `${index}`}
             paramsId={params.id}

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
@@ -46,11 +46,8 @@ export default function PlannerCharacterForm() {
   }
 
   const handleRemoveCharacter = (index: number) => {
-    setCharacters((prev) => {
-      const next = [...prev]
-      next.splice(index, 1)
-      return next
-    })
+    const newCharacters = characters.filter((_, i) => i !== index)
+    setCharacters(newCharacters)
   }
 
   return (

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 
 import { useEffect } from 'react'
 
+import { NEW_PLANNER_CHARACTER } from 'constants/planner/plannerConstants'
 import { useAtom } from 'jotai'
 import { useFormContext } from 'react-hook-form'
 import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
@@ -24,27 +25,7 @@ export default function PlannerCharacterForm() {
   const [formValues, setFormValues] = useAtom(plannerCharacterByIdAtom(params.id))
 
   const handleAddCharacter = () => {
-    setFormValues([
-      ...formValues.characters,
-      {
-        id: '',
-        intro: '',
-        name: '',
-        age: undefined,
-        gender: '',
-        occupation: '',
-        appearance: '',
-        personality: '',
-        relationship: '',
-        customFields: [
-          {
-            id: '',
-            name: '',
-            content: '',
-          },
-        ],
-      },
-    ])
+    setFormValues([...formValues.characters, NEW_PLANNER_CHARACTER])
   }
 
   const handleRemoveCharacter = (index: number) => {

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
@@ -16,7 +16,8 @@
 
   &__delete-button {
     position: absolute;
-    padding: 10px;
+    padding: 1rem;
+    top: 1rem;
     right: 0;
 
     transform: translateX(100%);

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
@@ -1,0 +1,23 @@
+@use '@styles/mixins' as mixin;
+
+.wrapper {
+  @include mixin.flex(row, center, null, nowrap);
+  min-height: 48px;
+
+  &--has-helper {
+    min-height: 80px;
+  }
+}
+
+.field-with-button {
+  @include mixin.flex(row, center, null, nowrap);
+  position: relative;
+  width: 100%;
+
+  &__delete-button {
+    position: absolute;
+    right: 0;
+
+    transform: translateX(calc(100% + 10px));
+  }
+}

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
@@ -16,8 +16,14 @@
 
   &__delete-button {
     position: absolute;
+    padding: 10px;
     right: 0;
 
-    transform: translateX(calc(100% + 10px));
+    transform: translateX(100%);
+    visibility: hidden;
+  }
+
+  &:hover .field-with-button__delete-button {
+    visibility: visible;
   }
 }

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.module.scss
@@ -2,11 +2,8 @@
 
 .wrapper {
   @include mixin.flex(row, center, null, nowrap);
-  min-height: 48px;
-
-  &--has-helper {
-    min-height: 80px;
-  }
+  min-height: 4.8rem;
+  max-height: 8rem;
 }
 
 .field-with-button {
@@ -16,8 +13,8 @@
 
   &__delete-button {
     position: absolute;
-    padding: 1rem;
-    top: 1rem;
+    padding: 1.2rem 0 1.2rem 1.2rem;
+    top: 0;
     right: 0;
 
     transform: translateX(100%);

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
@@ -14,6 +14,7 @@ interface PlannerFieldWithButtonProps {
   name: string
   hasHelperText?: boolean
   isDropdown?: boolean
+  onDelete?: () => void
 }
 
 export default function PlannerFieldWithButton({
@@ -21,6 +22,7 @@ export default function PlannerFieldWithButton({
   name,
   hasHelperText = true,
   isDropdown = false,
+  onDelete,
 }: PlannerFieldWithButtonProps) {
   const { watch, unregister, register, setValue } = useFormContext()
   const [isShow, setIsShow] = useState(true)
@@ -45,6 +47,7 @@ export default function PlannerFieldWithButton({
     setIsDeleted(true)
     setter(false)
     unregister(name)
+    if (onDelete) onDelete()
   }
 
   const restoreField = (setter: (v: boolean) => void) => {

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
@@ -12,7 +12,6 @@ const cx = classNames.bind(styles)
 interface PlannerFieldWithButtonProps {
   children: ReactNode
   name: string
-  hasHelperText?: boolean
   isDropdown?: boolean
   onDelete?: () => void
 }
@@ -20,7 +19,6 @@ interface PlannerFieldWithButtonProps {
 export default function PlannerFieldWithButton({
   children,
   name,
-  hasHelperText = true,
   isDropdown = false,
   onDelete,
 }: PlannerFieldWithButtonProps) {
@@ -58,11 +56,7 @@ export default function PlannerFieldWithButton({
   }
 
   return (
-    <div
-      className={cx('wrapper', {
-        'wrapper--has-helper': hasHelperText,
-      })}
-    >
+    <div className={cx('wrapper')}>
       {isShow ? (
         <div className={cx('field-with-button')}>
           {children}

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
@@ -30,6 +30,10 @@ export default function PlannerFieldWithButton({
       setIsShow(false)
     } else if (initialValue === '' || initialValue) {
       setIsShow(true)
+    } else if (name === 'synopsis.length' && initialValue === undefined) {
+      // NOTE(hajae): synopsis.length는 객체이기에 ''와 같은 빈값을 받을 수 없어 undefined로.
+      // null일때는 비표시, undefined일때는 표시
+      setIsShow(true)
     }
   }, [watch, name, initialValue])
 

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
@@ -20,7 +20,7 @@ export default function PlannerFieldWithButton({
   name,
   hasHelperText = true,
 }: PlannerFieldWithButtonProps) {
-  const { watch, unregister } = useFormContext()
+  const { watch, unregister, register, setValue } = useFormContext()
   const [isShow, setIsShow] = useState(true)
   const initialValue = watch(name)
 
@@ -28,6 +28,8 @@ export default function PlannerFieldWithButton({
   useEffect(() => {
     if (initialValue === null) {
       setIsShow(false)
+    } else if (initialValue === '' || initialValue) {
+      setIsShow(true)
     }
   }, [watch, name, initialValue])
 
@@ -37,6 +39,8 @@ export default function PlannerFieldWithButton({
   }
 
   const restoreField = (setter: (v: boolean) => void) => {
+    register(name)
+    setValue(name, '')
     setter(true)
   }
 

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
@@ -1,6 +1,8 @@
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 
 import { useFormContext } from 'react-hook-form'
+
+import FillButton from '@components/buttons/FillButton'
 
 import classNames from 'classnames/bind'
 
@@ -10,11 +12,24 @@ const cx = classNames.bind(styles)
 interface PlannerFieldWithButtonProps {
   children: ReactNode
   name: string
+  hasHelperText?: boolean
 }
 
-export default function PlannerFieldWithButton({ children, name }: PlannerFieldWithButtonProps) {
-  const { getValues, unregister } = useFormContext()
-  const [isShow, setIsShow] = useState(getValues(name) === null)
+export default function PlannerFieldWithButton({
+  children,
+  name,
+  hasHelperText = true,
+}: PlannerFieldWithButtonProps) {
+  const { watch, unregister } = useFormContext()
+  const [isShow, setIsShow] = useState(true)
+  const initialValue = watch(name)
+
+  // NOTE(hajae): 삭제된 항목은 null로 반환되어 초기 렌더링 시 화면에 표시하지 않는다
+  useEffect(() => {
+    if (initialValue === null) {
+      setIsShow(false)
+    }
+  }, [watch, name, initialValue])
 
   const removeField = (setter: (v: boolean) => void) => {
     unregister(name)
@@ -26,19 +41,35 @@ export default function PlannerFieldWithButton({ children, name }: PlannerFieldW
   }
 
   return (
-    <>
+    <div
+      className={cx('wrapper', {
+        'wrapper--has-helper': hasHelperText,
+      })}
+    >
       {isShow ? (
         <div className={cx('field-with-button')}>
           {children}
-          <button type="button" onClick={() => removeField(setIsShow)}>
-            삭제하기
-          </button>
+          <div className={cx('field-with-button__delete-button')}>
+            <FillButton
+              type="button"
+              size="small"
+              variant="secondary"
+              onClick={() => removeField(setIsShow)}
+            >
+              삭제하기
+            </FillButton>
+          </div>
         </div>
       ) : (
-        <button type="button" onClick={() => restoreField(setIsShow)}>
-          추가하기
-        </button>
+        <FillButton
+          type="button"
+          size="small"
+          variant="secondary"
+          onClick={() => restoreField(setIsShow)}
+        >
+          삭제된 항목 추가
+        </FillButton>
       )}
-    </>
+    </div>
   )
 }

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
@@ -1,0 +1,44 @@
+import { ReactNode, useState } from 'react'
+
+import { useFormContext } from 'react-hook-form'
+
+import classNames from 'classnames/bind'
+
+import styles from './PlannerFieldWithButton.module.scss'
+
+const cx = classNames.bind(styles)
+interface PlannerFieldWithButtonProps {
+  children: ReactNode
+  name: string
+}
+
+export default function PlannerFieldWithButton({ children, name }: PlannerFieldWithButtonProps) {
+  const { getValues, unregister } = useFormContext()
+  const [isShow, setIsShow] = useState(getValues(name) === null)
+
+  const removeField = (setter: (v: boolean) => void) => {
+    unregister(name)
+    setter(false)
+  }
+
+  const restoreField = (setter: (v: boolean) => void) => {
+    setter(true)
+  }
+
+  return (
+    <>
+      {isShow ? (
+        <div className={cx('field-with-button')}>
+          {children}
+          <button type="button" onClick={() => removeField(setIsShow)}>
+            삭제하기
+          </button>
+        </div>
+      ) : (
+        <button type="button" onClick={() => restoreField(setIsShow)}>
+          추가하기
+        </button>
+      )}
+    </>
+  )
+}

--- a/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-field-with-button/PlannerFieldWithButton.tsx
@@ -13,15 +13,18 @@ interface PlannerFieldWithButtonProps {
   children: ReactNode
   name: string
   hasHelperText?: boolean
+  isDropdown?: boolean
 }
 
 export default function PlannerFieldWithButton({
   children,
   name,
   hasHelperText = true,
+  isDropdown = false,
 }: PlannerFieldWithButtonProps) {
   const { watch, unregister, register, setValue } = useFormContext()
   const [isShow, setIsShow] = useState(true)
+  const [isDeleted, setIsDeleted] = useState(false)
   const initialValue = watch(name)
 
   // NOTE(hajae): 삭제된 항목은 null로 반환되어 초기 렌더링 시 화면에 표시하지 않는다
@@ -30,19 +33,22 @@ export default function PlannerFieldWithButton({
       setIsShow(false)
     } else if (initialValue === '' || initialValue) {
       setIsShow(true)
-    } else if (name === 'synopsis.length' && initialValue === undefined) {
-      // NOTE(hajae): synopsis.length는 객체이기에 ''와 같은 빈값을 받을 수 없어 undefined로.
+    } else if (isDropdown && initialValue === undefined && !isDeleted) {
+      // NOTE(hajae): Dropdown에 사용되는 데이터는 객체이기에 ''와 같은 빈값을 받을 수 없어 undefined로.
       // null일때는 비표시, undefined일때는 표시
+      // 삭제일 경우도 value가 undefined가 되기때문에 삭제시 다시표시됨. 따라서 삭제일때는 비표시하기위해 isDeleted 추가
       setIsShow(true)
     }
-  }, [watch, name, initialValue])
+  }, [watch, name, isDropdown, initialValue, isDeleted])
 
   const removeField = (setter: (v: boolean) => void) => {
-    unregister(name)
+    setIsDeleted(true)
     setter(false)
+    unregister(name)
   }
 
   const restoreField = (setter: (v: boolean) => void) => {
+    setIsDeleted(false)
     register(name)
     setValue(name, '')
     setter(true)

--- a/src/app/(after-login)/planner/[id]/_components/planner-plot-form/PlannerPlotForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-plot-form/PlannerPlotForm.tsx
@@ -1,5 +1,7 @@
 import TextField from '@components/text-field/TextField'
 
+import PlannerFieldWithButton from '../planner-field-with-button/PlannerFieldWithButton'
+
 import classNames from 'classnames/bind'
 
 import styles from './PlannerPlotForm.module.scss'
@@ -10,7 +12,9 @@ export default function PlannerPlotForm() {
   return (
     <div className={cx('plot-form')} id="heading4">
       <div className={cx('plot-form__title')}>줄거리</div>
-      <TextField name="plot.content" label="발단-전개-위기-결말" variant="expand" />
+      <PlannerFieldWithButton name="plot.content">
+        <TextField name="plot.content" label="발단-전개-위기-결말" variant="expand" />
+      </PlannerFieldWithButton>
     </div>
   )
 }

--- a/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form-container/PlannerSynopsisFormContainer.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form-container/PlannerSynopsisFormContainer.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect } from 'react'
+
 import { useAtom } from 'jotai'
 import { plannerActiveTabAtom } from 'store/plannerAtoms'
 
@@ -25,7 +27,13 @@ const TABLE_OF_CONTENTS = [
 ]
 
 export default function PlannerSynopsisFormContainer() {
-  const [activeTab] = useAtom(plannerActiveTabAtom)
+  const [activeTab, setActiveTab] = useAtom(plannerActiveTabAtom)
+
+  // NOTE(hajae): jotai는 전역상태이기 때문에 메모리에 상태가 살아있어서 아이디어 탭에서 페이지 이동후 다시 돌아올 경우
+  // 아이디어 탭이 활성화되어있음. 따라서, 마운트 될때 탭을 초기화하는 과정이 필요.
+  useEffect(() => {
+    setActiveTab('synopsis')
+  }, [])
 
   return (
     <form

--- a/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
@@ -52,7 +52,14 @@ export default function PlannerSynopsisForm() {
         name="synopsis.logline"
         label="로그 라인"
         variant="expand"
-        options={{ required: { value: true, message: 'required' } }}
+        options={{
+          required: { value: true, message: 'required' },
+          validate: (value) => {
+            if (value.trim() === '') {
+              return false
+            }
+          },
+        }}
       />
       <PlannerFieldWithButton name="synopsis.example">
         <TextField name="synopsis.example" label="예시 문장" variant="expand" />

--- a/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
@@ -6,6 +6,8 @@ import {
 import Dropdown from '@components/dropdown/Dropdown'
 import TextField from '@components/text-field/TextField'
 
+import PlannerFieldWithButton from '../planner-field-with-button/PlannerFieldWithButton'
+
 import classNames from 'classnames/bind'
 
 import styles from './PlannerSynopsisForm.module.scss'
@@ -39,7 +41,11 @@ export default function PlannerSynopsisForm() {
         options={PLANNER_SYNOPSIS_LENGTH}
         isRequired={false}
       />
-      <TextField name="synopsis.purpose" label="기획 의도" variant="expand" />
+
+      <PlannerFieldWithButton name="synopsis.purpose">
+        <TextField name="synopsis.purpose" label="기획 의도" variant="expand" />
+      </PlannerFieldWithButton>
+
       <TextField
         name="synopsis.logline"
         label="로그 라인"

--- a/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
@@ -33,7 +33,7 @@ export default function PlannerSynopsisForm() {
         isMulti={true}
         isRequired={true}
       />
-      <PlannerFieldWithButton name="synopsis.length" hasHelperText={false}>
+      <PlannerFieldWithButton name="synopsis.length" hasHelperText={false} isDropdown={true}>
         <Dropdown
           name="synopsis.length"
           type="outlined"

--- a/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
@@ -33,7 +33,7 @@ export default function PlannerSynopsisForm() {
         isMulti={true}
         isRequired={true}
       />
-      <PlannerFieldWithButton name="synopsis.length" hasHelperText={false} isDropdown={true}>
+      <PlannerFieldWithButton name="synopsis.length" isDropdown={true}>
         <Dropdown
           name="synopsis.length"
           type="outlined"
@@ -44,7 +44,7 @@ export default function PlannerSynopsisForm() {
         />
       </PlannerFieldWithButton>
 
-      <PlannerFieldWithButton name="synopsis.purpose" hasHelperText={false}>
+      <PlannerFieldWithButton name="synopsis.purpose">
         <TextField name="synopsis.purpose" label="기획 의도" variant="expand" />
       </PlannerFieldWithButton>
 
@@ -54,7 +54,7 @@ export default function PlannerSynopsisForm() {
         variant="expand"
         options={{ required: { value: true, message: 'required' } }}
       />
-      <PlannerFieldWithButton name="synopsis.example" hasHelperText={false}>
+      <PlannerFieldWithButton name="synopsis.example">
         <TextField name="synopsis.example" label="예시 문장" variant="expand" />
       </PlannerFieldWithButton>
     </div>

--- a/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
@@ -33,14 +33,16 @@ export default function PlannerSynopsisForm() {
         isMulti={true}
         isRequired={true}
       />
-      <Dropdown
-        name="synopsis.length"
-        type="outlined"
-        placeholder="분량"
-        label="분량"
-        options={PLANNER_SYNOPSIS_LENGTH}
-        isRequired={false}
-      />
+      <PlannerFieldWithButton name="synopsis.length" hasHelperText={false}>
+        <Dropdown
+          name="synopsis.length"
+          type="outlined"
+          placeholder="분량"
+          label="분량"
+          options={PLANNER_SYNOPSIS_LENGTH}
+          isRequired={false}
+        />
+      </PlannerFieldWithButton>
 
       <PlannerFieldWithButton name="synopsis.purpose" hasHelperText={false}>
         <TextField name="synopsis.purpose" label="기획 의도" variant="expand" />

--- a/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-synopsis-form/PlannerSynopsisForm.tsx
@@ -42,7 +42,7 @@ export default function PlannerSynopsisForm() {
         isRequired={false}
       />
 
-      <PlannerFieldWithButton name="synopsis.purpose">
+      <PlannerFieldWithButton name="synopsis.purpose" hasHelperText={false}>
         <TextField name="synopsis.purpose" label="기획 의도" variant="expand" />
       </PlannerFieldWithButton>
 
@@ -52,7 +52,9 @@ export default function PlannerSynopsisForm() {
         variant="expand"
         options={{ required: { value: true, message: 'required' } }}
       />
-      <TextField name="synopsis.example" label="예시 문장" variant="expand" />
+      <PlannerFieldWithButton name="synopsis.example" hasHelperText={false}>
+        <TextField name="synopsis.example" label="예시 문장" variant="expand" />
+      </PlannerFieldWithButton>
     </div>
   )
 }

--- a/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
@@ -36,11 +36,7 @@ export default function PlannerWorldViewForm() {
     <div className={cx('world-view-form')} id="heading2">
       <div className={cx('world-view-form__title')}>세계관</div>
       {PLANNER_WORLD_VIEW_ITEMS.map((item, index) => (
-        <PlannerFieldWithButton
-          key={item.name}
-          name={`worldview.${item.name}`}
-          hasHelperText={true}
-        >
+        <PlannerFieldWithButton key={item.name} name={`worldview.${item.name}`}>
           <TextField
             key={`planner-world-view-item-${index}`}
             name={`worldview.${item.name}`}
@@ -54,7 +50,6 @@ export default function PlannerWorldViewForm() {
         <PlannerFieldWithButton
           key={field.id || index}
           name={`worldview.customFields[${index}]`}
-          hasHelperText={false}
           onDelete={() => handleDeleteCustomField(index)}
         >
           <TextField

--- a/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react'
-
 import { PLANNER_WORLD_VIEW_ITEMS } from 'constants/planner/plannerConstants'
+import { useFormContext } from 'react-hook-form'
 
 import TextButton from '@components/buttons/TextButton'
 import TextField from '@components/text-field/TextField'
@@ -20,14 +19,17 @@ type CustomField = {
 }
 
 export default function PlannerWorldViewForm() {
-  const [customFields, setCustomFields] = useState<CustomField[]>([])
-
-  useEffect(() => {
-    setCustomFields([{ id: '', name: '', content: '' }])
-  }, [])
+  const { watch, setValue } = useFormContext()
+  const customFields: CustomField[] = watch('worldview.customFields') || []
 
   const handleAddCustomField = () => {
-    setCustomFields((prev) => [...prev, { id: '', name: '', content: '' }])
+    setValue('worldview.customFields', [...customFields, { id: '', name: '', content: '' }])
+  }
+
+  const handleDeleteCustomField = (index: number) => {
+    const updated = [...customFields]
+    updated.splice(index, 1)
+    setValue('worldview.customFields', updated)
   }
 
   return (
@@ -49,14 +51,20 @@ export default function PlannerWorldViewForm() {
         </PlannerFieldWithButton>
       ))}
       {customFields.map((field, index) => (
-        <TextField
+        <PlannerFieldWithButton
           key={field.id || index}
-          name={`worldview.customFields[${index}].content`}
-          label="커스텀 항목"
-          variant="expand"
-          labelName={`worldview.customFields[${index}].name`}
-          isLabelEditable={true}
-        />
+          name={`worldview.customFields[${index}]`}
+          hasHelperText={false}
+          onDelete={() => handleDeleteCustomField(index)}
+        >
+          <TextField
+            name={`worldview.customFields[${index}].content`}
+            label="커스텀 항목"
+            variant="expand"
+            labelName={`worldview.customFields[${index}].name`}
+            isLabelEditable={true}
+          />
+        </PlannerFieldWithButton>
       ))}
       {customFields.length < 15 && (
         <div className={cx('world-view-form__add-custom-field')}>

--- a/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
@@ -5,6 +5,8 @@ import { PLANNER_WORLD_VIEW_ITEMS } from 'constants/planner/plannerConstants'
 import TextButton from '@components/buttons/TextButton'
 import TextField from '@components/text-field/TextField'
 
+import PlannerFieldWithButton from '../planner-field-with-button/PlannerFieldWithButton'
+
 import classNames from 'classnames/bind'
 
 import styles from './PlannerWorldViewForm.module.scss'
@@ -32,13 +34,19 @@ export default function PlannerWorldViewForm() {
     <div className={cx('world-view-form')} id="heading2">
       <div className={cx('world-view-form__title')}>세계관</div>
       {PLANNER_WORLD_VIEW_ITEMS.map((item, index) => (
-        <TextField
-          key={`planner-world-view-item-${index}`}
+        <PlannerFieldWithButton
+          key={item.name}
           name={`worldview.${item.name}`}
-          label={item.label}
-          variant="expand"
-          helperText={item.helperText}
-        />
+          hasHelperText={true}
+        >
+          <TextField
+            key={`planner-world-view-item-${index}`}
+            name={`worldview.${item.name}`}
+            label={item.label}
+            variant="expand"
+            helperText={item.helperText}
+          />
+        </PlannerFieldWithButton>
       ))}
       {customFields.map((field, index) => (
         <TextField

--- a/src/app/(after-login)/planner/[id]/page.tsx
+++ b/src/app/(after-login)/planner/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useEffect, useState } from 'react'
 
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import { FormProvider, useForm } from 'react-hook-form'
 import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
 import { PlannerTemplatesRequest } from 'types/planner/plannerTemplatesRequest'
@@ -29,16 +29,15 @@ type Params = Promise<{ id: string }>
 function usePlannerData(params: Params) {
   const { id } = use(params)
   const { data: templates } = useFetchProductTemplates(id)
-  const [characters, setCharacters] = useAtom(plannerCharacterByIdAtom(id))
+  const characters = useAtomValue(plannerCharacterByIdAtom(id))
   const showToast = useToast()
   const { autoSaveTimer } = useAutoSaveTimer()
 
-  return { id, templates, characters, setCharacters, showToast, autoSaveTimer }
+  return { id, templates, characters, showToast, autoSaveTimer }
 }
 
 export default function PlannerPage({ params }: { params: Params }) {
-  const { id, templates, characters, setCharacters, showToast, autoSaveTimer } =
-    usePlannerData(params)
+  const { id, templates, characters, showToast, autoSaveTimer } = usePlannerData(params)
   const [isSaved, setIsSaved] = useState(false)
 
   const methods = useForm<PlannerSynopsisFormValues>()
@@ -70,39 +69,12 @@ export default function PlannerPage({ params }: { params: Params }) {
           templates.worldview !== null,
       )
 
-      const values = PlannerSynopsisFormValues.from(templates)
-
-      if (
-        values.characters.length > 0 &&
-        characters.length > 0 &&
-        values.characters.length === characters.length
-      ) {
-        const updatedCharacters = characters.map((char, index) => ({
-          ...char,
-          id: values.characters[index].id,
-        }))
-
-        setCharacters(updatedCharacters)
-
-        reset({
-          synopsis: values.synopsis,
-          worldview: values.worldview,
-          characters: updatedCharacters,
-          plot: values.plot,
-          ideaNote: values.ideaNote,
-        })
-
-        return
-      }
-
       reset({
-        synopsis: values.synopsis,
-        worldview: values.worldview,
-        // NOTE(hajae): local storage에 저장된 캐릭터가 우선
-        // https://www.notion.so/1678209b09f98067a6e7c8e3ef8b08ff?d=1cb8209b09f980e8bfb9001c4c150e72&pvs=4#1718209b09f980a6afbfd4244f71cb25
-        characters: characters ?? values.characters,
-        plot: values.plot,
-        ideaNote: values.ideaNote,
+        synopsis: templates.synopsis,
+        worldview: templates.worldview,
+        characters: characters ?? templates.characters,
+        plot: templates.plot,
+        ideaNote: templates.ideaNote,
       })
     }
   }, [reset, templates])

--- a/src/app/(after-login)/planner/[id]/page.tsx
+++ b/src/app/(after-login)/planner/[id]/page.tsx
@@ -89,7 +89,12 @@ export default function PlannerPage({ params }: { params: Params }) {
 
   return (
     <div className={cx('container')}>
-      <PlannerActionBar isValidFormValues={isValid} isSaved={isSaved} onSubmit={handleFormSubmit} />
+      <PlannerActionBar
+        productId={id}
+        isValidFormValues={isValid}
+        isSaved={isSaved}
+        onSubmit={handleFormSubmit}
+      />
       <div className={cx('main-section')}>
         <PlannerTabs />
         <FormProvider {...methods}>

--- a/src/app/(after-login)/planner/[id]/page.tsx
+++ b/src/app/(after-login)/planner/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useEffect, useState } from 'react'
 
-import { useAtomValue } from 'jotai'
+import { useAtom } from 'jotai'
 import { FormProvider, useForm } from 'react-hook-form'
 import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
 import { PlannerTemplatesRequest } from 'types/planner/plannerTemplatesRequest'
@@ -29,15 +29,16 @@ type Params = Promise<{ id: string }>
 function usePlannerData(params: Params) {
   const { id } = use(params)
   const { data: templates } = useFetchProductTemplates(id)
-  const characters = useAtomValue(plannerCharacterByIdAtom(id))
+  const [characters, setCharacters] = useAtom(plannerCharacterByIdAtom(id))
   const showToast = useToast()
   const { autoSaveTimer } = useAutoSaveTimer()
 
-  return { id, templates, characters, showToast, autoSaveTimer }
+  return { id, templates, characters, setCharacters, showToast, autoSaveTimer }
 }
 
 export default function PlannerPage({ params }: { params: Params }) {
-  const { id, templates, characters, showToast, autoSaveTimer } = usePlannerData(params)
+  const { id, templates, characters, setCharacters, showToast, autoSaveTimer } =
+    usePlannerData(params)
   const [isSaved, setIsSaved] = useState(false)
 
   const methods = useForm<PlannerSynopsisFormValues>()
@@ -71,12 +72,35 @@ export default function PlannerPage({ params }: { params: Params }) {
 
       const values = PlannerSynopsisFormValues.from(templates)
 
+      if (
+        values.characters.length > 0 &&
+        characters.length > 0 &&
+        values.characters.length === characters.length
+      ) {
+        const updatedCharacters = characters.map((char, index) => ({
+          ...char,
+          id: values.characters[index].id,
+        }))
+
+        setCharacters(updatedCharacters)
+
+        reset({
+          synopsis: values.synopsis,
+          worldview: values.worldview,
+          characters: updatedCharacters,
+          plot: values.plot,
+          ideaNote: values.ideaNote,
+        })
+
+        return
+      }
+
       reset({
         synopsis: values.synopsis,
         worldview: values.worldview,
         // NOTE(hajae): local storage에 저장된 캐릭터가 우선
         // https://www.notion.so/1678209b09f98067a6e7c8e3ef8b08ff?d=1cb8209b09f980e8bfb9001c4c150e72&pvs=4#1718209b09f980a6afbfd4244f71cb25
-        characters: values.characters, // TODO(hajae): characters ?? values.characters -> id도 같이 덮어버려 request error 발생
+        characters: characters ?? values.characters,
         plot: values.plot,
         ideaNote: values.ideaNote,
       })
@@ -87,7 +111,7 @@ export default function PlannerPage({ params }: { params: Params }) {
     if (isSuccess) {
       showToast('success', '저장이 완료되었습니다.')
     }
-  }, [isSuccess, showToast])
+  }, [isSuccess])
 
   return (
     <div className={cx('container')}>

--- a/src/app/(after-login)/planner/[id]/page.tsx
+++ b/src/app/(after-login)/planner/[id]/page.tsx
@@ -29,11 +29,11 @@ type Params = Promise<{ id: string }>
 function usePlannerData(params: Params) {
   const { id } = use(params)
   const { data: templates } = useFetchProductTemplates(id)
-  const characters = useAtomValue(plannerCharacterByIdAtom(id))
+  const formValues = useAtomValue(plannerCharacterByIdAtom(id))
   const showToast = useToast()
   const { autoSaveTimer } = useAutoSaveTimer()
 
-  return { id, templates, characters, showToast, autoSaveTimer }
+  return { id, templates, characters: formValues.characters, showToast, autoSaveTimer }
 }
 
 export default function PlannerPage({ params }: { params: Params }) {

--- a/src/app/(after-login)/planner/[id]/page.tsx
+++ b/src/app/(after-login)/planner/[id]/page.tsx
@@ -9,6 +9,7 @@ import { PlannerTemplatesRequest } from 'types/planner/plannerTemplatesRequest'
 
 import { useToast } from '@components/toast/ToastProvider'
 
+import { useAutoSaveTimer } from '@hooks/products/useAutoSaveTimer'
 import { useCreateProductTemplates } from '@hooks/products/useProductsMutation'
 import { useFetchProductTemplates } from '@hooks/products/useProductsQueries'
 
@@ -30,12 +31,13 @@ function usePlannerData(params: Params) {
   const { data: templates } = useFetchProductTemplates(id)
   const characters = useAtomValue(plannerCharacterByIdAtom(id))
   const showToast = useToast()
+  const { autoSaveTimer } = useAutoSaveTimer()
 
-  return { id, templates, characters, showToast }
+  return { id, templates, characters, showToast, autoSaveTimer }
 }
 
 export default function PlannerPage({ params }: { params: Params }) {
-  const { id, templates, characters, showToast } = usePlannerData(params)
+  const { id, templates, characters, showToast, autoSaveTimer } = usePlannerData(params)
   const [isSaved, setIsSaved] = useState(false)
 
   const methods = useForm<PlannerSynopsisFormValues>()
@@ -94,6 +96,7 @@ export default function PlannerPage({ params }: { params: Params }) {
         isValidFormValues={isValid}
         isSaved={isSaved}
         onSubmit={handleFormSubmit}
+        autoSaveTimer={autoSaveTimer}
       />
       <div className={cx('main-section')}>
         <PlannerTabs />

--- a/src/app/(after-login)/planner/[id]/page.tsx
+++ b/src/app/(after-login)/planner/[id]/page.tsx
@@ -37,7 +37,7 @@ export default function PlannerPage({ params }: { params: Params }) {
 
   const methods = useForm<PlannerSynopsisFormValues>()
   const {
-    setValue,
+    reset,
     formState: { isValid },
     handleSubmit,
   } = methods
@@ -57,16 +57,17 @@ export default function PlannerPage({ params }: { params: Params }) {
 
       const values = PlannerSynopsisFormValues.from(templates)
 
-      setValue('synopsis', values.synopsis)
-      setValue('synopsis.length', values.synopsis.length) // NOTE(hajae): nested object 필드. setValue('synopsis')만으로는 하위 필드 변경 감지 안됨
-      setValue('worldview', values.worldview)
-      // NOTE(hajae): local storage에 저장된 캐릭터가 우선
-      // https://www.notion.so/1678209b09f98067a6e7c8e3ef8b08ff?d=1cb8209b09f980e8bfb9001c4c150e72&pvs=4#1718209b09f980a6afbfd4244f71cb25
-      setValue('characters', characters ?? values.characters)
-      setValue('plot', values.plot)
-      setValue('ideaNote', values.ideaNote)
+      reset({
+        synopsis: values.synopsis,
+        worldview: values.worldview,
+        // NOTE(hajae): local storage에 저장된 캐릭터가 우선
+        // https://www.notion.so/1678209b09f98067a6e7c8e3ef8b08ff?d=1cb8209b09f980e8bfb9001c4c150e72&pvs=4#1718209b09f980a6afbfd4244f71cb25
+        characters: values.characters, // TODO(hajae): characters ?? values.characters -> id도 같이 덮어버려 request error 발생
+        plot: values.plot,
+        ideaNote: values.ideaNote,
+      })
     }
-  }, [setValue, templates])
+  }, [reset, templates])
 
   const handleFormSubmit = handleSubmit((formValues) => {
     const request = PlannerTemplatesRequest.from(formValues, characters)

--- a/src/app/(after-login)/planner/[id]/page.tsx
+++ b/src/app/(after-login)/planner/[id]/page.tsx
@@ -69,13 +69,7 @@ export default function PlannerPage({ params }: { params: Params }) {
   useEffect(() => {
     if (templates) {
       // NOTE(hajae): fetch된 데이터가 하나라도 있으면 이미 저장된 상태로 간주
-      setIsSaved(
-        templates.characters.length > 0 ||
-          templates.ideaNote !== null ||
-          templates.plot !== null ||
-          templates.synopsis !== null ||
-          templates.worldview !== null,
-      )
+      setIsSaved(templates.isSaved)
 
       // NOTE(hajae): 서버에 저장된 ID가 존재하고, Local Storage에 저장된 ID가 없을 경우 ID를 SET
       // 현재 사양은 클라이언트에 저장된 데이터를 우선으로 Character를 SET

--- a/src/app/api/products/products.ts
+++ b/src/app/api/products/products.ts
@@ -1,4 +1,5 @@
 import { default as AuthAxios, default as authInstance } from 'api/core/AuthInstance'
+import axios from 'axios'
 import { IdeaNotePresignedUrlRequest } from 'types/planner/ideaNotePresignedUrl'
 import { PlannerTemplatesRequest } from 'types/planner/plannerTemplatesRequest'
 import { PlannerTemplatesResponse } from 'types/planner/plannerTemplatesResponse'
@@ -48,4 +49,18 @@ export const createProductsTemplates = async (
 export const createFilesPresignedUrl = async (request: IdeaNotePresignedUrlRequest) => {
   const res = await AuthAxios.post(`/files/presigned-url`, { ...request })
   return res.data
+}
+
+export const updateIdeaNoteImage = async (putUrl: string, file: File) => {
+  // NOTE(hajae): base url이 필요없기에 아래와 같이 작성
+  const res = await axios
+    .create({
+      timeout: 15000,
+      withCredentials: true,
+    })
+    .put(putUrl, file, {
+      headers: { 'Content-Type': file.type },
+    })
+
+  return res
 }

--- a/src/app/api/products/products.ts
+++ b/src/app/api/products/products.ts
@@ -1,6 +1,7 @@
 import { default as AuthAxios, default as authInstance } from 'api/core/AuthInstance'
 import axios from 'axios'
 import { IdeaNotePresignedUrlRequest } from 'types/planner/ideaNotePresignedUrl'
+import { PlannerSynopsisFormValues } from 'types/planner/plannerSynopsisFormValues'
 import { PlannerTemplatesRequest } from 'types/planner/plannerTemplatesRequest'
 import { PlannerTemplatesResponse } from 'types/planner/plannerTemplatesResponse'
 import {
@@ -35,7 +36,7 @@ export const getProductDetail = async (productId: string) => {
 
 export const fetchProductsTemplates = async (productId: string) => {
   const res = await AuthAxios.get<PlannerTemplatesResponse>(`/products/${productId}/templates`)
-  return res.data.result
+  return PlannerSynopsisFormValues.from(res.data.result)
 }
 
 export const createProductsTemplates = async (

--- a/src/app/api/products/products.ts
+++ b/src/app/api/products/products.ts
@@ -1,4 +1,5 @@
 import { default as AuthAxios, default as authInstance } from 'api/core/AuthInstance'
+import { IdeaNotePresignedUrlRequest } from 'types/planner/ideaNotePresignedUrl'
 import { PlannerTemplatesRequest } from 'types/planner/plannerTemplatesRequest'
 import { PlannerTemplatesResponse } from 'types/planner/plannerTemplatesResponse'
 import {
@@ -41,5 +42,10 @@ export const createProductsTemplates = async (
   request: PlannerTemplatesRequest,
 ) => {
   const res = await AuthAxios.post(`/products/${productId}/templates`, { ...request })
+  return res.data
+}
+
+export const createFilesPresignedUrl = async (request: IdeaNotePresignedUrlRequest) => {
+  const res = await AuthAxios.post(`/files/presigned-url`, { ...request })
   return res.data
 }

--- a/src/app/components/dropdown/Dropdown.module.scss
+++ b/src/app/components/dropdown/Dropdown.module.scss
@@ -4,6 +4,7 @@
 
 .container {
   position: relative;
+  width: 100%;
 
   .custom-select {
     &.required.closed {

--- a/src/app/components/editor/planner-idea-note-editor/PlannerIdeaNoteEditor.tsx
+++ b/src/app/components/editor/planner-idea-note-editor/PlannerIdeaNoteEditor.tsx
@@ -115,10 +115,6 @@ export default function PlannerIdeaNoteEditor({
     }
   }, [editor, contents])
 
-  useImperativeHandle(ref, () => ({
-    getEditor: () => editor,
-  }))
-
   useEffect(() => {
     if (!editor) return
 
@@ -126,11 +122,15 @@ export default function PlannerIdeaNoteEditor({
       const items = event.clipboardData?.items
       if (!items) return
 
+      // NOTE(hajae): 붙여넣기 시 base64 이미지가 포함되어 있는지 확인
       const htmlData = event.clipboardData?.getData('text/html')
+      const tempDiv = document.createElement('div')
+      tempDiv.innerHTML = htmlData ?? ''
+      const hasBase64Image = !!tempDiv.querySelector('img[src^="data:image/"]')
 
-      if (htmlData?.includes('src="data:image')) {
+      // NOTE(hajae): base64 이미지가 포함되어 있으면 기본 붙여넣기 동작을 막음
+      if (hasBase64Image) {
         event.preventDefault()
-        return
       }
 
       for (const item of items) {
@@ -152,12 +152,12 @@ export default function PlannerIdeaNoteEditor({
       }
     }
 
-    editor.view.dom.addEventListener('paste', handlePaste)
+    editor.view.dom.addEventListener('paste', handlePaste, true)
 
     return () => {
-      editor.view.dom.removeEventListener('paste', handlePaste)
+      editor.view.dom.removeEventListener('paste', handlePaste, true)
     }
-  }, [editor])
+  }, [createPresignedUrlMutation, editor])
 
   if (!editor) {
     return null

--- a/src/app/components/editor/planner-idea-note-editor/PlannerIdeaNoteEditor.tsx
+++ b/src/app/components/editor/planner-idea-note-editor/PlannerIdeaNoteEditor.tsx
@@ -126,6 +126,13 @@ export default function PlannerIdeaNoteEditor({
       const items = event.clipboardData?.items
       if (!items) return
 
+      const htmlData = event.clipboardData?.getData('text/html')
+
+      if (htmlData?.includes('src="data:image')) {
+        event.preventDefault()
+        return
+      }
+
       for (const item of items) {
         if (item.type.startsWith('image/')) {
           event.preventDefault()

--- a/src/app/components/editor/planner-idea-note-editor/PlannerIdeaNoteEditor.tsx
+++ b/src/app/components/editor/planner-idea-note-editor/PlannerIdeaNoteEditor.tsx
@@ -42,6 +42,7 @@ export default function PlannerIdeaNoteEditor({
   contents,
 }: PlannerIdeaNoteEditorProps) {
   const createPresignedUrlMutation = useCreateFilesPresignedUrl({
+    // NOTE(hajae): 이미지 업로드 순서는 useIdeaNoteImageUpload.ts 참고
     onSuccess: (fileGetUrl) => {
       if (editor) {
         editor

--- a/src/app/components/text-field/TextFieldLabel.tsx
+++ b/src/app/components/text-field/TextFieldLabel.tsx
@@ -78,7 +78,6 @@ export default function TextFieldLabel({
         />
       ) : (
         <label
-          htmlFor={name}
           className={cx('text-field__fieldset__label', {
             'text-field__fieldset__label--active': value,
             'text-field__fieldset__label--editable': isLabelEditable,

--- a/src/app/constants/planner/plannerConstants.ts
+++ b/src/app/constants/planner/plannerConstants.ts
@@ -1,4 +1,18 @@
+import { CharacterFormValues } from 'types/planner/plannerSynopsisFormValues'
 import { PlannerTabType } from 'types/planner/plannerTab'
+
+export const NEW_PLANNER_CHARACTER: CharacterFormValues = {
+  id: '',
+  intro: '',
+  name: '',
+  age: undefined,
+  gender: '',
+  occupation: '',
+  appearance: '',
+  personality: '',
+  relationship: '',
+  customFields: [],
+}
 
 export const PLANNER_TABS: PlannerTabType[] = [
   {

--- a/src/app/hooks/products/useAutoSaveTimer.ts
+++ b/src/app/hooks/products/useAutoSaveTimer.ts
@@ -18,6 +18,7 @@ export const useAutoSaveTimer = (initialTime = 300000) => {
         stopTimer()
         setTimeout(() => {
           setAutoSaveTimer(initialTime)
+          startTimer()
         }, 3000)
         return 0
       }

--- a/src/app/hooks/products/useAutoSaveTimer.ts
+++ b/src/app/hooks/products/useAutoSaveTimer.ts
@@ -16,10 +16,13 @@ export const useAutoSaveTimer = (initialTime = 300000) => {
         return time - 1000
       } else {
         stopTimer()
+        setTimeout(() => {
+          setAutoSaveTimer(initialTime)
+        }, 3000)
         return 0
       }
     },
-    [stopTimer],
+    [stopTimer, initialTime],
   )
 
   const startTimer = useCallback(() => {

--- a/src/app/hooks/products/useAutoSaveTimer.ts
+++ b/src/app/hooks/products/useAutoSaveTimer.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export const useAutoSaveTimer = (initialTime = 300000) => {
+  const [autoSaveTimer, setAutoSaveTimer] = useState(initialTime)
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+    }
+  }, [])
+
+  const decrementTimer = useCallback(
+    (time: number) => {
+      if (time > 1000) {
+        return time - 1000
+      } else {
+        stopTimer()
+        return 0
+      }
+    },
+    [stopTimer],
+  )
+
+  const startTimer = useCallback(() => {
+    timerRef.current = setInterval(() => {
+      setAutoSaveTimer((prevTime) => decrementTimer(prevTime))
+    }, 1000)
+  }, [decrementTimer])
+
+  useEffect(() => {
+    startTimer()
+
+    return () => {
+      stopTimer()
+    }
+  }, [startTimer, stopTimer])
+
+  return {
+    autoSaveTimer,
+    startTimer,
+    stopTimer,
+    resetTimer: () => setAutoSaveTimer(initialTime),
+  }
+}

--- a/src/app/hooks/products/useIdeaNoteImageUpload.ts
+++ b/src/app/hooks/products/useIdeaNoteImageUpload.ts
@@ -9,6 +9,13 @@ import {
 export const useCreateFilesPresignedUrl = (mutationOptions?: UseMutationCustomOptions) => {
   return useMutation({
     mutationFn: async ({ request, file }: { request: IdeaNotePresignedUrlRequest; file: File }) => {
+      /* NOTE(hajae)
+       * 이미지 업로드 순서
+       * 1. 이미지 붙여넣기 || 이미지 첨부
+       * 2. POST files/presigned-url 요청
+       * 3. (files/presigned-url 요청의) response.filePutUrl로 이미지 PUT (서버에 저장)
+       * 4. response.fileGetUrl로 이미지 표시 (예시. <img src={fileGetUrl} ...>)
+       */
       const res: IdeaNotePresignedUrlResponse = await createFilesPresignedUrl(request)
       await updateIdeaNoteImage(res.result.filePutUrl, file)
       return res.result.fileGetUrl

--- a/src/app/hooks/products/useIdeaNoteImageUpload.ts
+++ b/src/app/hooks/products/useIdeaNoteImageUpload.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query'
+import { createFilesPresignedUrl } from 'api/products/products'
+import { UseMutationCustomOptions } from 'types/common/reactQueryCustomOption'
+import { IdeaNotePresignedUrlRequest } from 'types/planner/ideaNotePresignedUrl'
+
+export const useCreateFilesPresignedUrl = (mutationOptions?: UseMutationCustomOptions) => {
+  return useMutation({
+    mutationFn: ({ request }: { request: IdeaNotePresignedUrlRequest }) =>
+      createFilesPresignedUrl(request),
+    ...mutationOptions,
+  })
+}

--- a/src/app/hooks/products/useIdeaNoteImageUpload.ts
+++ b/src/app/hooks/products/useIdeaNoteImageUpload.ts
@@ -1,12 +1,18 @@
 import { useMutation } from '@tanstack/react-query'
-import { createFilesPresignedUrl } from 'api/products/products'
+import { createFilesPresignedUrl, updateIdeaNoteImage } from 'api/products/products'
 import { UseMutationCustomOptions } from 'types/common/reactQueryCustomOption'
-import { IdeaNotePresignedUrlRequest } from 'types/planner/ideaNotePresignedUrl'
+import {
+  IdeaNotePresignedUrlRequest,
+  IdeaNotePresignedUrlResponse,
+} from 'types/planner/ideaNotePresignedUrl'
 
 export const useCreateFilesPresignedUrl = (mutationOptions?: UseMutationCustomOptions) => {
   return useMutation({
-    mutationFn: ({ request }: { request: IdeaNotePresignedUrlRequest }) =>
-      createFilesPresignedUrl(request),
+    mutationFn: async ({ request, file }: { request: IdeaNotePresignedUrlRequest; file: File }) => {
+      const res: IdeaNotePresignedUrlResponse = await createFilesPresignedUrl(request)
+      await updateIdeaNoteImage(res.result.filePutUrl, file)
+      return res.result.fileGetUrl
+    },
     ...mutationOptions,
   })
 }

--- a/src/app/hooks/products/useProductsQueries.ts
+++ b/src/app/hooks/products/useProductsQueries.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchProductsTemplates, getProductDetail, getProductList } from 'api/products/products'
 import { QUERY_KEY } from 'constants/common/queryKeys'
 import { UseQueryCustomOptions } from 'types/common/reactQueryCustomOption'
-import { PlannerTemplates } from 'types/planner/plannerTemplatesResponse'
+import { PlannerSynopsisFormValues } from 'types/planner/plannerSynopsisFormValues'
 import { ProductDetailDto, ProductDto } from 'types/products'
 
 export const useGetProductList = (queryOptions?: UseQueryCustomOptions<ProductDto[]>) => {
@@ -27,7 +27,7 @@ export const useGetProductDetail = (
 
 export const useFetchProductTemplates = (
   productId: string,
-  queryOptions?: UseQueryCustomOptions<PlannerTemplates>,
+  queryOptions?: UseQueryCustomOptions<PlannerSynopsisFormValues>,
 ) => {
   return useQuery({
     queryKey: [QUERY_KEY.PRODUCT_TEMPLATES, productId],

--- a/src/app/store/plannerAtoms.ts
+++ b/src/app/store/plannerAtoms.ts
@@ -42,17 +42,24 @@ export const plannerCharacterByIdAtom = atomFamily((plannerId: string) => {
     set: Setter,
     update: CharacterFormValues[] | ((prev: CharacterFormValues[]) => CharacterFormValues[]),
   ) => {
-    const all = get(plannerCharacterFormValuesAtom)
-    const index = all.findIndex((entry) => entry.plannerId === plannerId)
-    const prev = index === -1 ? [] : all[index].characters
-    const next = typeof update === 'function' ? update(prev) : update
+    const characterForms = get(plannerCharacterFormValuesAtom)
+    const targetFromIndex = characterForms.findIndex((form) => form.plannerId === plannerId)
+    const prev = characterForms[targetFromIndex].characters
+    const updatedForm = typeof update === 'function' ? update(prev) : update
 
-    const updatedAll =
-      index === -1
-        ? [...all, { plannerId, characters: next }]
-        : all.map((entry, i) => (i === index ? { ...entry, characters: next } : entry))
+    const updatedCharacterForms =
+      targetFromIndex === -1
+        ? [...characterForms, { plannerId, characters: [...updatedForm] }]
+        : characterForms.map((form, index) =>
+            index === targetFromIndex
+              ? {
+                  ...form,
+                  characters: [...updatedForm],
+                }
+              : form,
+          )
 
-    set(plannerCharacterFormValuesAtom, updatedAll)
+    set(plannerCharacterFormValuesAtom, updatedCharacterForms)
   }
 
   const baseAtom = atom(getCharactersByPlannerId, updateCharactersByPlannerId)

--- a/src/app/store/plannerAtoms.ts
+++ b/src/app/store/plannerAtoms.ts
@@ -1,3 +1,4 @@
+import { NEW_PLANNER_CHARACTER } from 'constants/planner/plannerConstants'
 import { Getter, Setter, atom } from 'jotai'
 import { atomFamily, atomWithStorage } from 'jotai/utils'
 import {
@@ -21,19 +22,6 @@ export const plannerCharacterFormValuesAtom = atomWithStorage<PlannerTemplateFor
 )
 
 export const plannerCharacterByIdAtom = atomFamily((plannerId: string) => {
-  const createCharacter = (): CharacterFormValues => ({
-    id: '',
-    intro: '',
-    name: '',
-    age: undefined,
-    gender: '',
-    occupation: '',
-    appearance: '',
-    personality: '',
-    relationship: '',
-    customFields: [],
-  })
-
   const getCharactersByPlannerId = (get: Getter) => {
     const all = get(plannerCharacterFormValuesAtom)
     return (
@@ -91,7 +79,7 @@ export const plannerCharacterByIdAtom = atomFamily((plannerId: string) => {
       set({
         plannerId,
         ...PlannerSynopsisFormValues.from(undefined),
-        characters: [createCharacter()],
+        characters: [NEW_PLANNER_CHARACTER],
       } as PlannerTemplateFormValueType)
     }
   }

--- a/src/app/types/planner/ideaNotePresignedUrl.ts
+++ b/src/app/types/planner/ideaNotePresignedUrl.ts
@@ -1,0 +1,25 @@
+import { ApiResponse } from 'types/common/apiResponse'
+
+export type IdeaNotePresignedUrlResponse = ApiResponse<IdeaNotePresignedUrl>
+export type IdeaNotePresignedUrl = {
+  filePutUrl: string
+  fileGetUrl: string
+}
+
+export type IdeaNotePresignedUrlRequest = {
+  fileUploadType: 'idea-note'
+  originalFileName: string
+  contentType: 'image/png'
+  contentLength: number
+}
+
+export const IdeaNotePresignedUrlRequest = {
+  from: (name: string, contentLength: number): IdeaNotePresignedUrlRequest => {
+    return {
+      fileUploadType: 'idea-note',
+      originalFileName: name,
+      contentType: 'image/png',
+      contentLength: contentLength,
+    }
+  },
+}

--- a/src/app/types/planner/plannerSynopsisFormValues.ts
+++ b/src/app/types/planner/plannerSynopsisFormValues.ts
@@ -74,7 +74,7 @@ export const PlannerSynopsisFormValues = {
     if (!synopsis) {
       return {
         genre: [],
-        length: null,
+        length: undefined,
         purpose: '',
         logline: '',
         example: '',

--- a/src/app/types/planner/plannerSynopsisFormValues.ts
+++ b/src/app/types/planner/plannerSynopsisFormValues.ts
@@ -12,7 +12,7 @@ export type PlannerSynopsisFormValues = {
 
 export type SynopsisFormValues = {
   genre: { label: string; value: string }[]
-  length?: { label: string; value: string }
+  length?: { label: string; value: string } | null
   purpose?: string
   logline: string
   example?: string
@@ -74,7 +74,7 @@ export const PlannerSynopsisFormValues = {
     if (!synopsis) {
       return {
         genre: [],
-        length: undefined,
+        length: null,
         purpose: '',
         logline: '',
         example: '',
@@ -89,7 +89,7 @@ export const PlannerSynopsisFormValues = {
       genre: genres.map((genre) => {
         return { label: genre, value: genre }
       }),
-      length: length,
+      length: synopsis.length === '' || length ? length : null,
     }
   },
 

--- a/src/app/types/planner/plannerSynopsisFormValues.ts
+++ b/src/app/types/planner/plannerSynopsisFormValues.ts
@@ -52,7 +52,7 @@ export type PlotFormValues = {
   content?: string
 }
 
-export type CustomField = { id: string; name: string; content: string }
+export type CustomField = { id?: string; name: string; content: string }
 
 export type IdeaNoteFormValues = {
   title: string

--- a/src/app/types/planner/plannerSynopsisFormValues.ts
+++ b/src/app/types/planner/plannerSynopsisFormValues.ts
@@ -8,6 +8,7 @@ export type PlannerSynopsisFormValues = {
   characters: CharacterFormValues[]
   plot: PlotFormValues
   ideaNote: IdeaNoteFormValues
+  isSaved: boolean
 }
 
 export type SynopsisFormValues = {
@@ -67,6 +68,12 @@ export const PlannerSynopsisFormValues = {
       characters: PlannerSynopsisFormValues.toCharacterFormValues(res?.characters),
       plot: PlannerSynopsisFormValues.toPlotFormValues(res?.plot),
       ideaNote: PlannerSynopsisFormValues.toIdeaNoteFormValues(res?.ideaNote),
+      isSaved:
+        (res?.characters?.length ?? 0) > 0 ||
+        res?.ideaNote !== null ||
+        res?.plot !== null ||
+        res?.synopsis !== null ||
+        res?.worldview !== null,
     }
   },
 

--- a/src/app/types/planner/plannerSynopsisFormValues.ts
+++ b/src/app/types/planner/plannerSynopsisFormValues.ts
@@ -44,7 +44,6 @@ export type CharacterFormValues = {
   occupation?: string
   appearance?: string
   personality?: string
-  characteristic?: string
   relationship?: string
   customFields?: CustomField[]
 }

--- a/src/app/types/planner/plannerSynopsisFormValues.ts
+++ b/src/app/types/planner/plannerSynopsisFormValues.ts
@@ -60,17 +60,17 @@ export type IdeaNoteFormValues = {
 }
 
 export const PlannerSynopsisFormValues = {
-  from: (res: PlannerTemplates): PlannerSynopsisFormValues => {
+  from: (res: PlannerTemplates | undefined): PlannerSynopsisFormValues => {
     return {
-      synopsis: PlannerSynopsisFormValues.toSynopsisFormValues(res.synopsis),
-      worldview: PlannerSynopsisFormValues.toWorldViewFormValues(res.worldview),
-      characters: PlannerSynopsisFormValues.toCharacterFormValues(res.characters),
-      plot: PlannerSynopsisFormValues.toPlotFormValues(res.plot),
-      ideaNote: PlannerSynopsisFormValues.toIdeaNoteFormValues(res.ideaNote),
+      synopsis: PlannerSynopsisFormValues.toSynopsisFormValues(res?.synopsis),
+      worldview: PlannerSynopsisFormValues.toWorldViewFormValues(res?.worldview),
+      characters: PlannerSynopsisFormValues.toCharacterFormValues(res?.characters),
+      plot: PlannerSynopsisFormValues.toPlotFormValues(res?.plot),
+      ideaNote: PlannerSynopsisFormValues.toIdeaNoteFormValues(res?.ideaNote),
     }
   },
 
-  toSynopsisFormValues: (synopsis: Synopsis): SynopsisFormValues => {
+  toSynopsisFormValues: (synopsis: Synopsis | undefined): SynopsisFormValues => {
     if (!synopsis) {
       return {
         genre: [],
@@ -93,7 +93,7 @@ export const PlannerSynopsisFormValues = {
     }
   },
 
-  toWorldViewFormValues: (worldview: WorldViewFormValues): WorldViewFormValues => {
+  toWorldViewFormValues: (worldview: WorldViewFormValues | undefined): WorldViewFormValues => {
     if (!worldview) {
       return {
         geography: '',
@@ -116,7 +116,7 @@ export const PlannerSynopsisFormValues = {
     return worldview
   },
 
-  toCharacterFormValues: (characters: CharacterFormValues[]): CharacterFormValues[] => {
+  toCharacterFormValues: (characters: CharacterFormValues[] | undefined): CharacterFormValues[] => {
     if (!characters) {
       return []
     }
@@ -127,7 +127,7 @@ export const PlannerSynopsisFormValues = {
     }))
   },
 
-  toPlotFormValues: (plot: PlotFormValues): PlotFormValues => {
+  toPlotFormValues: (plot: PlotFormValues | undefined): PlotFormValues => {
     if (!plot) {
       return {
         content: '',
@@ -137,7 +137,7 @@ export const PlannerSynopsisFormValues = {
     return plot
   },
 
-  toIdeaNoteFormValues: (ideaNote: IdeaNoteFormValues): IdeaNoteFormValues => {
+  toIdeaNoteFormValues: (ideaNote: IdeaNoteFormValues | undefined): IdeaNoteFormValues => {
     if (!ideaNote) {
       return {
         title: '',

--- a/src/app/types/planner/plannerTemplatesRequest.ts
+++ b/src/app/types/planner/plannerTemplatesRequest.ts
@@ -12,7 +12,7 @@ export const PlannerTemplatesRequest = {
       // NOTE(hajae): 값이 존재하지 않으면 '', 삭제한 항목이면 undefined로 삭제 유무를 구분한다.
       synopsis: {
         genre: formValues.synopsis.genre.map((genre) => genre.value).join(', '),
-        length: formValues.synopsis.length?.value,
+        length: formValues.synopsis.length?.value || '',
         purpose: formValues.synopsis.purpose,
         logline: formValues.synopsis.logline,
         example: formValues.synopsis.example,
@@ -33,9 +33,9 @@ export const PlannerTemplatesRequest = {
         conflict: formValues.worldview.conflict,
         customFields: formValues.worldview.customFields
           ? Object.values(formValues.worldview.customFields).map((field) => ({
-              id: field.id,
-              name: field.name,
-              content: field.content,
+              id: field.id || undefined,
+              name: field.name || '',
+              content: field.content || '',
             }))
           : [],
       },
@@ -43,7 +43,7 @@ export const PlannerTemplatesRequest = {
         id: character.id,
         intro: character.intro,
         name: character.name || '',
-        age: character.age,
+        age: Number(character.age),
         gender: character.gender,
         occupation: character.occupation,
         appearance: character.appearance,
@@ -51,7 +51,7 @@ export const PlannerTemplatesRequest = {
         relationship: character.relationship,
         customFields: character.customFields
           ? character.customFields.map((field) => ({
-              id: field.id || '',
+              id: field.id || undefined,
               name: field.name || '',
               content: field.content || '',
             }))

--- a/src/app/types/planner/plannerTemplatesRequest.ts
+++ b/src/app/types/planner/plannerTemplatesRequest.ts
@@ -12,7 +12,11 @@ export const PlannerTemplatesRequest = {
       // NOTE(hajae): 값이 존재하지 않으면 '', 삭제한 항목이면 undefined로 삭제 유무를 구분한다.
       synopsis: {
         genre: formValues.synopsis.genre.map((genre) => genre.value).join(', '),
-        length: formValues.synopsis.length?.value || '',
+        length: formValues.synopsis.length
+          ? formValues.synopsis.length.value
+          : formValues.synopsis.length === undefined
+            ? undefined
+            : '',
         purpose: formValues.synopsis.purpose,
         logline: formValues.synopsis.logline,
         example: formValues.synopsis.example,

--- a/src/app/types/planner/plannerTemplatesRequest.ts
+++ b/src/app/types/planner/plannerTemplatesRequest.ts
@@ -48,7 +48,6 @@ export const PlannerTemplatesRequest = {
         occupation: character.occupation,
         appearance: character.appearance,
         personality: character.personality,
-        characteristic: character.characteristic,
         relationship: character.relationship,
         customFields: character.customFields
           ? character.customFields.map((field) => ({

--- a/src/app/types/planner/plannerTemplatesRequest.ts
+++ b/src/app/types/planner/plannerTemplatesRequest.ts
@@ -62,7 +62,7 @@ export const PlannerTemplatesRequest = {
           : [],
       })),
       plot: {
-        content: formValues.plot.content,
+        content: formValues.plot?.content,
       },
       ideaNote: {
         title: formValues.ideaNote.title || '',

--- a/src/app/types/planner/plannerTemplatesResponse.ts
+++ b/src/app/types/planner/plannerTemplatesResponse.ts
@@ -11,7 +11,7 @@ export type PlannerTemplates = {
 }
 
 type CustomField = {
-  id: string
+  id?: string
   name: string
   content: string
 }

--- a/src/app/types/planner/plannerTemplatesResponse.ts
+++ b/src/app/types/planner/plannerTemplatesResponse.ts
@@ -25,7 +25,6 @@ export type Character = {
   occupation?: string
   appearance?: string
   personality?: string
-  characteristic?: string
   relationship?: string
   customFields?: CustomField[]
 }

--- a/src/app/utils/formatDate.ts
+++ b/src/app/utils/formatDate.ts
@@ -13,3 +13,7 @@ export const formatDate = (dateString: string) => {
 
   return `${year}.${month}.${day}`
 }
+
+export const formatMillisecondToMinute = (millisecond: number) => {
+  return Math.floor(millisecond / 60000)
+}

--- a/src/app/utils/formatDate.ts
+++ b/src/app/utils/formatDate.ts
@@ -15,5 +15,5 @@ export const formatDate = (dateString: string) => {
 }
 
 export const formatMillisecondToMinute = (millisecond: number) => {
-  return Math.floor(millisecond / 60000)
+  return Math.ceil(millisecond / 60000)
 }


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
작업플래너의 템플릿 저장
- 이미지 저장
- Request Model 수정
- 항목별 삭제 버튼 추가
- 자동저장 타이머 추가

> ## 관련 이슈
- close [#110](https://writelyforwriters.atlassian.net/browse/KAN-110)

> ## 변경 사항
- 이미지 저장
- Request Model 수정
- 항목별 삭제 버튼 추가
- 자동저장 타이머 추가

> ## 스크린샷 (필요한 경우)

### 저장버튼 비활성화
![May-07-2025 18-56-07](https://github.com/user-attachments/assets/dad24036-5827-4bb9-961c-11bb914aaa66)

### 


> ## 추가 정보

### 추후 논의사항
![May-11-2025 20-35-06](https://github.com/user-attachments/assets/753e3c41-331d-4094-acc5-7cae248f1f5d)

타이틀 수정 + 타이머가 같은 컴포넌트 내에 있어서 1초마다 리렌더링을 해서 수정모드도 리렌더링해서 수정을 할 수가 없음

```tsx
<>
  {isTitleEditing ? (
    <input
      className={cx('action-bar-input')}
      value={title}
      onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
      onBlur={handleBlur}
      onKeyDown={handleKeyDown}
    />
  ) : (
    <span className={cx('action-bar-span')} onClick={() => setIsTitleEditing(true)}>
      {title}
    </span>
  )}
  {/* NOTE(hajae): 현재 테스트 */}
  <span className={cx('description')}>
    {autoSaveTimer > 0
      ? `${formatMillisecondToMinute(autoSaveTimer)}분 뒤에 자동 저장됩니다.`
      : '저장 중입니다.'}
  </span>
</>

...

  return (
    <ActionBar // 이 컴포넌트에서 타이틀부분, 타이머 부분을 따로 빼내야할 필요가 있어보임
      actionSection={<ActionSectionContent />}
      titleSection={<TitleSectionContent />}
      extraSection={<ExtraSectionContent />}
    />
  )
```


수정사항이 많은데 궁금한 점 있으신 곳은 전부 코멘트 달아주세요!!
