### PR TITLE
[KAN-140] Feat: ai-assistant 자동 수정 기능 구현

### DIFF
--- a/src/app/api/ai-assistant/aiAssistant.ts
+++ b/src/app/api/ai-assistant/aiAssistant.ts
@@ -6,6 +6,12 @@ interface PromptData {
   prompt: string
 }
 
+// 자동 수정
+export const postAutoModify = async (promptData: Omit<PromptData, 'prompt'>) => {
+  const res = await authInstance.post('/assistant/auto-modify', promptData)
+  return res.data.result
+}
+
 // 수동 수정
 export const postUserModify = async (promptData: PromptData) => {
   const res = await authInstance.post('/assistant/user-modify', promptData)

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -23,6 +23,7 @@ import HeadingExtension from '@extensions/Heading'
 import Indent from '@extensions/Indent'
 
 import Toolbar from './Toolbar'
+import AutoModifyMenu from './ai-assistant-interface/AutoModifyMenu'
 import FeedbackMenu from './ai-assistant-interface/FeedbackMenu'
 import ManualModification from './ai-assistant-interface/ManualModification'
 
@@ -79,9 +80,12 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
     isOpen,
     onClose,
     feedbackInput,
+    selectionRef,
+    isAutoModifyVisible,
     handleActiveMenu,
     handlePromptChange,
     handleAiPrompt,
+    handleOptionClickAutoModify,
     handleOptionClickUserModify,
     handleOptionClickFeedback,
   } = useTextEditor(editor)
@@ -130,6 +134,16 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
           />
         )}
       </BubbleMenu>
+
+      {/* 자동 수정 */}
+      {activeMenu === 'auto-modify' && (
+        <AutoModifyMenu
+          editor={editor}
+          selectionRef={selectionRef}
+          isVisible={isAutoModifyVisible}
+          onOptionClick={handleOptionClickAutoModify}
+        />
+      )}
 
       {/* 수동 수정 */}
       {activeMenu === 'user-modify' && (

--- a/src/app/components/editor/ai-assistant-interface/AutoModifyMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/AutoModifyMenu.tsx
@@ -1,0 +1,112 @@
+import Image from 'next/image'
+
+import { RefObject, useEffect, useRef, useState } from 'react'
+
+import { Editor } from '@tiptap/react'
+import { FaCheck } from 'react-icons/fa6'
+import { IoClose } from 'react-icons/io5'
+import { ActionOptionType, TextSelectionRangeType } from 'types/common/editor'
+
+import Portal from '@components/modal/Portal'
+import SelectMenuContent from '@components/select-menu/SelectMenuContent'
+
+import styles from '../DefaultEditor.module.scss'
+
+interface AutoModifyMenuProps {
+  editor: Editor
+  selectionRef: RefObject<TextSelectionRangeType | null>
+  isVisible: boolean
+  onOptionClick: (option: ActionOptionType) => () => void
+}
+
+// MEMO(Sohyun): ai-assistant 인터페이스 자동 수정 UI
+export default function AutoModifyMenu({
+  editor,
+  selectionRef,
+  isVisible,
+  onOptionClick,
+}: AutoModifyMenuProps) {
+  const [position, setPosition] = useState({ top: 0, left: 0 })
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // MEMO(Sohyun): 텍스트 에디터에서 특정 영역을 선택했을 때, 그 선택 영역 기준으로 메뉴 UI를 띄우기 위한 좌표 계산
+  // BubbleMenu는 에디터 내용 변경 시 초기화되는 문제로 직접 좌표를 계산한 UI를 구현함
+  useEffect(() => {
+    if (!isVisible || !editor || !selectionRef?.current) return
+
+    // 선택 범위의 좌표 계산
+    const { from, to } = selectionRef?.current
+    const view = editor.view
+
+    try {
+      // MEMO(Sohyun): view.coordsAtPos(pos)는 에디터 문서 내 특정 문자 인덱스(pos)에 해당하는 브라우저 상의 실제 좌표를 반환하는 Prosemirror API
+      // (참고) https://prosemirror.net/docs/ref/#view.EditorView.coordsAtPos
+      const startCoords = view.coordsAtPos(from)
+      const endCoords = view.coordsAtPos(to)
+
+      // 선택된 영역의 가로 중앙 위치 계산
+      const centerX = (startCoords.left + endCoords.left) / 2
+
+      // 텍스트 아래 여백(8px)을 두고, 가운데 정렬로 배치
+      setPosition({
+        top: endCoords.bottom + 8,
+        left: centerX,
+      })
+    } catch (error) {
+      console.error(error)
+    }
+  }, [editor, selectionRef, isVisible])
+
+  if (!isVisible) return null
+
+  return (
+    <Portal>
+      <div
+        ref={menuRef}
+        // 스타일 위치를 동적으로 계산해야 하므로 인라인 스타일 적용
+        style={{
+          width: 200,
+          position: 'absolute',
+          top: `${position.top}px`,
+          left: `${position.left}px`,
+          transform: 'translateX(-50%)',
+          zIndex: 100,
+        }}
+      >
+        <SelectMenuContent>
+          <SelectMenuContent.Option option={{ handleAction: onOptionClick('apply') }}>
+            <FaCheck color="#CCCCCC" fontSize={20} style={{ padding: '2px' }} />
+            이대로 수정하기
+          </SelectMenuContent.Option>
+          <SelectMenuContent.Option option={{ handleAction: onOptionClick('recreate') }}>
+            <Image src="/icons/refresh.svg" alt="다시 생성하기" width={20} height={20} />
+            다시 생성하기
+          </SelectMenuContent.Option>
+          <SelectMenuContent.Option option={{ handleAction: onOptionClick('cancel') }}>
+            <IoClose color="#CCCCCC" fontSize={20} />
+            취소하기
+          </SelectMenuContent.Option>
+          <div className={styles['divide-line']}></div>
+          {/* TODO 응답 및 보관 기능 */}
+          <SelectMenuContent.Option option={{ handleAction: () => {} }}>
+            <Image src="/icons/feedback-good-icon.svg" alt="good" width={20} height={20} />
+            응답이 마음에 들어요
+          </SelectMenuContent.Option>
+          <SelectMenuContent.Option option={{ handleAction: () => {} }}>
+            <Image src="/icons/feedback-bad-icon.svg" alt="not good" width={20} height={20} />
+            응답이 별로에요
+          </SelectMenuContent.Option>
+          <SelectMenuContent.Option option={{ handleAction: () => {} }}>
+            <Image
+              src="/icons/permanent-saved-icon.svg"
+              alt="답변 영구 보관하기"
+              width={20}
+              height={20}
+            />
+            답변 영구 보관하기
+          </SelectMenuContent.Option>
+        </SelectMenuContent>
+      </div>
+    </Portal>
+  )
+}

--- a/src/app/types/common/editor.ts
+++ b/src/app/types/common/editor.ts
@@ -11,6 +11,6 @@ export interface TextSelectionRangeType {
   to: number
 }
 
-export type ToolbarType = 'defaultToolbar' | 'user-modify' | 'feedback'
+export type ToolbarType = 'defaultToolbar' | 'auto-modify' | 'user-modify' | 'feedback'
 export type AiassistantOptionType = 'auto-modify' | 'user-modify' | 'feedback' | 'free-chat'
 export type ActionOptionType = 'apply' | 'recreate' | 'cancel'


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- AI 어시스턴트 자동 수정 기능을 구현했습니다.
- 기능 명세서는 [KAN-140](https://writelyforwriters.atlassian.net/browse/KAN-140?atlOrigin=eyJpIjoiOTY1ZTJmNjEwZDBlNDczZGE5ODBhZmYwZDNjZjUwZDUiLCJwIjoiaiJ9)을 참고해주세요.

<br />

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- [KAN-140](https://writelyforwriters.atlassian.net/browse/KAN-140?atlOrigin=eyJpIjoiOTY1ZTJmNjEwZDBlNDczZGE5ODBhZmYwZDNjZjUwZDUiLCJwIjoiaiJ9)

<br />

> ## 변경 사항
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- 자동 수정 API 연동
- 자동 수정에 대한 이대로 수정하기, 다시 생성하기, 취소하기 기능 구현
- 선택한 텍스트 위치 기반 플로팅 자동 수정 UI 구현

<br />

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
![자동수정](https://github.com/user-attachments/assets/b3f7c4cf-ab21-4072-a0b0-6881031e996f)


<br />

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
- 이후 작업 계획: 응답에 대한 피드백 및 답변 영구 보관 기능 > 수동 수정 UI 수정
- 이전 구간 피드백 기능에서 선우님께서 확인해 주신 동일한 응답이 오는 부분 관련하여, 자동 수정도 거의 비슷한 응답이 오는 것을 확인했습니다. 확인 요청드릴때 자동 수정 기능도 함께 확인하도록 하겠습니다.
- [수동 수정 PR](https://github.com/WritelyForWriters/FE/pull/89)에서 한번 언급드린 문제(구조상 에디터 내용이 변경되면, 내부적으로 Tiptap의 transaction이 발생하면서, 버블 메뉴가 사라지는 문제로인해, 수동 수정 UI의 경우 상단에 고정 프롬프트를 생성 - 디자인과 다름)가 있었는데, 자동 수정 기능을 구현하면서 동일한 문제가 있어서 사용자가 드래그한 텍스트의 좌표를 계산하여 직접 플로팅 메뉴를 띄우는 방식으로 해결했습니다!! 다만, 수동 수정 UI에는 적용 전으로 나머지 기능 구현하고 적용하겠습니다. 자세한 내용은 마찬가지로 [KAN-140](https://writelyforwriters.atlassian.net/browse/KAN-140?atlOrigin=eyJpIjoiOTY1ZTJmNjEwZDBlNDczZGE5ODBhZmYwZDNjZjUwZDUiLCJwIjoiaiJ9)을 참고해주세요.
- 시간내서 확인해 주셔서 늘 감사합니다. 

<br />


[KAN-140]: https://writelyforwriters.atlassian.net/browse/KAN-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-140]: https://writelyforwriters.atlassian.net/browse/KAN-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-140]: https://writelyforwriters.atlassian.net/browse/KAN-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ