### PR TITLE
KAN-152 fix: 읽기 모드에서도 툴바가 노출 및 작동됨

### DIFF
--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -122,10 +122,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
           maxWidth: 'none',
           interactive: true,
         }}
-        // --shouldShow: 버블 메뉴 표시를 제어하는 콜백
-        /* MEMO(Sohyun): DefaultEditor내부에서 editable 상태에따른 화면을 구현하고 싶었으나, 버블메뉴 shouldShow 상태 제어가 안되는 문제가 있음
-          editable상태가 shouldShow에 즉각반영이 안됨, (참고) https://tiptap.dev/docs/guides/output-json-html#render */
-        shouldShow={({ state }) => editable && !state.selection.empty}
+        shouldShow={({ editor, state }) => editor.isEditable && !state.selection.empty}
       >
         {activeMenu === 'defaultToolbar' && (
           <Toolbar editor={editor} handleActiveMenu={handleActiveMenu} />


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- 읽기 모드에서도 구간 선택 시 툴바가 나타나고, 이를 조작하면 텍스트 서식 변경도 가능함

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- close [#152](https://writelyforwriters.atlassian.net/browse/KAN-152)

> ## 변경 사항
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- 읽기모드에서 구간 
선택시 툴바가 표시되지 않게함

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
![kan-152-1](https://github.com/user-attachments/assets/1cda442b-0bfc-4014-b73b-00a0dd6bb4e8)

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
