### PR TITLE
Fix: [QA] Favicon 스타일 수정

### DIFF
--- a/src/app/(after-login)/workspace/[id]/page.module.scss
+++ b/src/app/(after-login)/workspace/[id]/page.module.scss
@@ -16,6 +16,7 @@
 /* main */
 .main-section {
   padding: 0 1.6rem;
+  min-height: 80vh;
 
   display: grid;
   grid-template-columns: 244px minmax(568px, 1fr) 244px;

--- a/src/app/(after-login)/workspace/[id]/page.tsx
+++ b/src/app/(after-login)/workspace/[id]/page.tsx
@@ -7,11 +7,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Editor } from '@tiptap/react'
 import { AUTO_SAVE_MESSAGE } from 'constants/workspace/message'
 import { DELAY_TIME } from 'constants/workspace/number'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { chatbotFixedMessageAtom } from 'store/chatbotFixedMessageAtom'
 import { chatbotHistoryAtom } from 'store/chatbotHistoryAtom'
 import { autoSaveMessageAtom, editorContentAtom, isEditableAtom } from 'store/editorAtoms'
-import { newChatMessagesAtom } from 'store/newChatMessagesAtom'
 import { productIdAtom, productTitleAtom } from 'store/productsAtoms'
 import { HandleEditor } from 'types/common/editor'
 import { ModalHandler } from 'types/common/modalRef'
@@ -57,7 +56,6 @@ export default function WorkSpacePage() {
   const { data: memoList } = useGetMemoList(params.id) // MEMO(Sohyun): 메모 컴포넌트에서 요청하는것이 좋을까?
 
   const [productTitle, setProductTitle] = useAtom(productTitleAtom)
-  const newChatMessages = useAtomValue(newChatMessagesAtom)
   const setIsContentEditing = useSetAtom(isEditableAtom)
   const editorContent = editorContentAtom(params.id)
   const setEditorContent = useSetAtom(editorContent)
@@ -201,8 +199,8 @@ export default function WorkSpacePage() {
       }
     }
 
-    setChatbotHistory([...newChatMessages, ...allChats])
-  }, [previousChatbotHistory, productId, newChatMessages, setChatbotHistory])
+    setChatbotHistory(allChats)
+  }, [previousChatbotHistory, productId])
 
   useEffect(() => {
     setFixedMessage(
@@ -245,11 +243,9 @@ export default function WorkSpacePage() {
             <PlannerPannel />
           </div>
         </div>
-      </main>
 
-      <div>
         <ChatbotLauncher />
-      </div>
+      </main>
 
       <Modal
         ref={modalRef}

--- a/src/app/components/chatbot-chat-input/ChatbotChatInput.tsx
+++ b/src/app/components/chatbot-chat-input/ChatbotChatInput.tsx
@@ -20,7 +20,6 @@ import { chatbotHistoryAtom } from 'store/chatbotHistoryAtom'
 import { chatbotSelectedIndexAtom } from 'store/chatbotSelectedIndexAtom'
 import { clickedButtonAtom } from 'store/clickedButtonAtom'
 import { isAssistantRespondingAtom } from 'store/isAssistantRespondingAtom'
-import { newChatMessagesAtom } from 'store/newChatMessagesAtom'
 import { productIdAtom } from 'store/productsAtoms'
 import { selectedPromptAtom } from 'store/selectedPromptAtom'
 import { selectedRangeAtom } from 'store/selectedRangeAtom'
@@ -60,7 +59,7 @@ export default function ChatbotChatInput() {
 
   const setSelectedIndex = useSetAtom(chatbotSelectedIndexAtom)
   const setIsAssistantResponding = useSetAtom(isAssistantRespondingAtom)
-  const setNewChatMessages = useSetAtom(newChatMessagesAtom)
+  const setChatbotHistory = useSetAtom(chatbotHistoryAtom)
 
   const showToast = useToast()
 
@@ -83,7 +82,7 @@ export default function ChatbotChatInput() {
       onSuccess: async (data) => {
         try {
           const newMessage = await getAssistantHistoryById(productId, data as string)
-          setNewChatMessages((prev) => [newMessage.result.contents[0], ...prev])
+          setChatbotHistory((prev) => [newMessage.result.contents[0], ...prev])
         } catch {}
       },
     })

--- a/src/app/components/chatbot-floating-favicon/ChatbotFloatingFavicon.tsx
+++ b/src/app/components/chatbot-floating-favicon/ChatbotFloatingFavicon.tsx
@@ -61,7 +61,7 @@ export default function ChatbotFloatingFavicon() {
 
     setChatbotAbsolutePosition({ x: chatbotX, y: chatbotY })
     setChatbotRelativePosition(computeRelativePosition(chatbotX, chatbotY, width, height))
-  }, [faviconRelativePosition, windowSize, setChatbotAbsolutePosition, setChatbotRelativePosition])
+  }, [faviconRelativePosition, windowSize])
 
   const handleDragStop = (_: DraggableEvent, data: { x: number; y: number }) => {
     const { width, height } = windowSize
@@ -92,8 +92,11 @@ export default function ChatbotFloatingFavicon() {
       position={faviconAbsolutePosition}
       onDragStop={handleDragStop}
       enableResizing={false}
-      bounds="window"
+      bounds="parent"
       dragHandleClassName="drag-handle"
+      style={{
+        position: 'fixed',
+      }}
     >
       <div className={cx('favicon-wrapper')}>
         <Favicon onClick={handleChatbotOpen}>

--- a/src/app/components/chatbot-window/ChatbotWindow.tsx
+++ b/src/app/components/chatbot-window/ChatbotWindow.tsx
@@ -4,7 +4,7 @@
  */
 import Image from 'next/image'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Identify, identify } from '@amplitude/analytics-browser'
 import { CHATBOT_DEFAULT_SIZE } from 'constants/chatbot/number'
@@ -102,12 +102,12 @@ export default function ChatbotWindow() {
     setChatbotAbsoluteSize,
   ])
 
-  const handleScroll = async () => {
+  const handleScroll = useCallback(() => {
     const container = containerRef.current
     if (container && container.scrollTop + container.clientHeight >= container.scrollHeight - 10) {
       fetchNextPage()
     }
-  }
+  }, [fetchNextPage])
 
   useEffect(() => {
     const container = containerRef.current

--- a/src/app/store/faviconRelativePositionAtom.ts
+++ b/src/app/store/faviconRelativePositionAtom.ts
@@ -1,3 +1,3 @@
 import { atom } from 'jotai'
 
-export const faviconRelativePositionAtom = atom({ xRatio: 0.9, yRatio: 0.8 })
+export const faviconRelativePositionAtom = atom({ xRatio: 0.9, yRatio: 0.7 })

--- a/src/app/store/newChatMessagesAtom.ts
+++ b/src/app/store/newChatMessagesAtom.ts
@@ -1,4 +1,0 @@
-import { atom } from 'jotai'
-import { ChatItem } from 'types/chatbot/chatbot'
-
-export const newChatMessagesAtom = atom<ChatItem[] | []>([])


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- favicon의 position을 `fixed`로 변경하여 화면 하단 고정 및 부모 영역 내에서만 이동 가능하도록 수정
- 챗봇 사용 내역 조회 로직 수정
> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- [KAN-149](https://writelyforwriters.atlassian.net/browse/KAN-149)
- [QA](https://www.notion.so/AI-2038209b09f98008b571cd5bde47e0b7?source=copy_link)

> ## 변경 사항
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- `favicon`의 `position`을 `fixed`로 설정
- 부모 컨테이너 영역 내에서만 favicon 이동 가능하도록 bounds를 `"parent"`로 변경
- 챗봇 사용 내역 조회 시 오류가 발생하여 해당 부분 로직 수정
- `useGetInfiniteAssistantHistory` 훅을 사용하는 무한 스크롤 로직 개선
  - 스크롤 이벤트 핸들러 최적화

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
> **Before**

![Write On - Chrome 2025-05-30 12-23-58](https://github.com/user-attachments/assets/25b6de94-dc8e-41b7-bbf8-42a698a02f58)


> **After**

https://github.com/user-attachments/assets/4a45b85d-fc6d-44d2-a2e0-c74d39e35023

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
- @ParkSohyunee  favicon을 부모 영역인 `작업 공간` - 작업 영역 안에서만 이동 가능하도록 작업 영역에 `min-height: 80vh`를 추가했는데 혹시 문제가 되는 코드면 다른 방안을 모색해보겠습니다...!


[KAN-149]: https://writelyforwriters.atlassian.net/browse/KAN-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ