### PR TITLE
[KAN-156] Fix: QA editor

### DIFF
--- a/src/app/(after-login)/workspace/[id]/_components/memo-pannel/MemoItem.tsx
+++ b/src/app/(after-login)/workspace/[id]/_components/memo-pannel/MemoItem.tsx
@@ -123,7 +123,7 @@ export default function MemoItem({ memoList, activeTab }: MemoItemProps) {
   return (
     <li className={cx('memo-item')}>
       <div>
-        <h3>{title ?? '타이틀'}</h3>
+        <h3>{selectedText}</h3>
         <div className={cx('memo-item__button')}>
           {(activeTab === 'progress' || (activeTab === 'all' && isCompleted)) && (
             <>

--- a/src/app/components/action-bar/ActionBar.module.scss
+++ b/src/app/components/action-bar/ActionBar.module.scss
@@ -17,7 +17,7 @@
   gap: 1rem;
 
   background-color: color.$alert-secondary-0;
-  z-index: 1;
+  z-index: 200;
 }
 
 // 액션바 내부 컨테이너

--- a/src/app/components/editor/DefaultEditor.module.scss
+++ b/src/app/components/editor/DefaultEditor.module.scss
@@ -50,7 +50,7 @@
 
 .prompt-menu {
   width: 462px;
-  height: 52px;
+  min-height: 52px;
 
   padding: 0.8rem;
   padding-left: 1.6rem;
@@ -64,13 +64,15 @@
 
   &__input {
     flex: 1;
-    height: 100%;
+    height: 17px;
 
     @extend %typo-body-medium;
     color: color.$core-secondary-100;
 
     border: none;
     outline: none;
+    resize: none;
+    cursor: default;
   }
 }
 

--- a/src/app/components/editor/DefaultEditor.module.scss
+++ b/src/app/components/editor/DefaultEditor.module.scss
@@ -48,12 +48,6 @@
   }
 }
 
-/* Ai-assistant interface 1 Option menu styles */
-.container {
-  position: fixed;
-  z-index: 10;
-}
-
 .prompt-menu {
   width: 462px;
   height: 52px;

--- a/src/app/components/editor/DefaultEditor.module.scss
+++ b/src/app/components/editor/DefaultEditor.module.scss
@@ -48,34 +48,6 @@
   }
 }
 
-.prompt-menu {
-  width: 462px;
-  min-height: 52px;
-
-  padding: 0.8rem;
-  padding-left: 1.6rem;
-
-  @include mixin.flex(row, center, space-between);
-  gap: 1.6rem;
-
-  border-radius: 1.2rem;
-  background: color.$alert-secondary-0;
-  box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.1);
-
-  &__input {
-    flex: 1;
-    height: 17px;
-
-    @extend %typo-body-medium;
-    color: color.$core-secondary-100;
-
-    border: none;
-    outline: none;
-    resize: none;
-    cursor: default;
-  }
-}
-
 .select-menu {
   position: relative;
   width: 200px;

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -127,6 +127,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
           duration: 100,
           maxWidth: 'none',
           interactive: true,
+          zIndex: 100,
         }}
         shouldShow={({ editor, state }) => editor.isEditable && !state.selection.empty}
       >

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -84,6 +84,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
   }))
 
   const {
+    isOpen,
     feedback,
     activeMenu,
     feedbackInput,
@@ -172,6 +173,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
       {/* 수동 수정 */}
       {activeMenu === 'user-modify' && (
         <ManualModification
+          isPrimaryActionMenuOpen={isOpen}
           editor={editor}
           selectionRef={selectionRef}
           onPromptChange={handlePromptChange}

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -16,8 +16,6 @@ import { useAtomValue } from 'jotai'
 import { isEditableAtom } from 'store/editorAtoms'
 import { HandleEditor } from 'types/common/editor'
 
-import FillButton from '@components/buttons/FillButton'
-
 import { useMemos } from '@hooks/editor/useMemos'
 import { useTextEditor } from '@hooks/editor/useTextEditor'
 
@@ -31,6 +29,7 @@ import Toolbar from './Toolbar'
 import AutoModifyMenu from './ai-assistant-interface/AutoModifyMenu'
 import FeedbackMenu from './ai-assistant-interface/FeedbackMenu'
 import ManualModification from './ai-assistant-interface/ManualModification'
+import PromptInput from './common/PromptInput'
 
 import styles from './DefaultEditor.module.scss'
 
@@ -136,26 +135,14 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
         )}
 
         {/* 메모 */}
+        {/* TODO 메모도 focusout or blur 시 하이라이트 사라지거나 or Portal로 UI 고정되도롣 */}
         {activeMenu === 'memo' && (
-          <div className={styles['prompt-menu']}>
-            <input
-              autoFocus
-              className={styles['prompt-menu__input']}
-              onChange={handleChange}
-              placeholder="메모를 입력해주세요."
-            />
-            <FillButton
-              size="medium"
-              variant="primary"
-              style={{
-                padding: '0.8rem 1.2rem',
-                height: '100%',
-              }}
-              onClick={handleSavedMemos}
-            >
-              저장하기
-            </FillButton>
-          </div>
+          <PromptInput
+            onPromptInputChange={handleChange}
+            onSubmit={handleSavedMemos}
+            placeholder="메모를 입력해주세요."
+            buttonText="저장하기"
+          />
         )}
       </BubbleMenu>
 

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -86,8 +86,6 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
   const {
     feedback,
     activeMenu,
-    isOpen,
-    onClose,
     feedbackInput,
     selectionRef,
     isAutoModifyVisible,
@@ -176,8 +174,6 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
         <ManualModification
           editor={editor}
           selectionRef={selectionRef}
-          isOpen={isOpen}
-          onClose={onClose}
           onPromptChange={handlePromptChange}
           onAiPrompt={handleAiPrompt}
           onOptionClick={handleOptionClickUserModify}

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -135,16 +135,6 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
           <Toolbar editor={editor} handleActiveMenu={handleActiveMenu} />
         )}
 
-        {/* 구간 피드백 */}
-        {activeMenu === 'feedback' && (
-          <FeedbackMenu
-            feedbackText={feedbackInput.current}
-            onOptionClick={handleOptionClickFeedback}
-            feedback={feedback}
-            handleSubmitFeedback={handleSubmitFeedback}
-          />
-        )}
-
         {/* 메모 */}
         {activeMenu === 'memo' && (
           <div className={styles['prompt-menu']}>
@@ -189,6 +179,18 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
           onPromptChange={handlePromptChange}
           onAiPrompt={handleAiPrompt}
           onOptionClick={handleOptionClickUserModify}
+          feedback={feedback}
+          handleSubmitFeedback={handleSubmitFeedback}
+        />
+      )}
+
+      {/* 구간 피드백 */}
+      {activeMenu === 'feedback' && (
+        <FeedbackMenu
+          editor={editor}
+          selectionRef={selectionRef}
+          feedbackText={feedbackInput.current}
+          onOptionClick={handleOptionClickFeedback}
           feedback={feedback}
           handleSubmitFeedback={handleSubmitFeedback}
         />

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -174,6 +174,8 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
       {/* 수동 수정 */}
       {activeMenu === 'user-modify' && (
         <ManualModification
+          editor={editor}
+          selectionRef={selectionRef}
           isOpen={isOpen}
           onClose={onClose}
           onPromptChange={handlePromptChange}

--- a/src/app/components/editor/DefaultEditor.tsx
+++ b/src/app/components/editor/DefaultEditor.tsx
@@ -85,6 +85,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
 
   const {
     isOpen,
+    feedbackPrompt,
     feedback,
     activeMenu,
     feedbackInput,
@@ -187,6 +188,7 @@ export default function DefaultEditor({ editorRef, isSavedRef, contents }: Defau
       {/* 구간 피드백 */}
       {activeMenu === 'feedback' && (
         <FeedbackMenu
+          isFeedbackPromptMenuOpen={feedbackPrompt}
           editor={editor}
           selectionRef={selectionRef}
           feedbackText={feedbackInput.current}

--- a/src/app/components/editor/ai-assistant-interface/AutoModifyMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/AutoModifyMenu.tsx
@@ -1,10 +1,12 @@
-import { ChangeEvent, RefObject, useEffect, useRef, useState } from 'react'
+import { ChangeEvent, RefObject, useRef, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
 import { ActionOptionType, EvaluateStateType, TextSelectionRangeType } from 'types/common/editor'
 
 import Portal from '@components/modal/Portal'
+
+import useUpdatePosition from '@hooks/editor/useUpdatePosition'
 
 import FeedbackOptionMenu from './menu/FeedbackOptionMenu'
 import PrimaryActionMenu from './menu/PrimaryActionMenu'
@@ -27,7 +29,8 @@ export default function AutoModifyMenu({
   onOptionClick,
   handleSubmitFeedback,
 }: AutoModifyMenuProps) {
-  const [position, setPosition] = useState({ top: 0, left: 0 })
+  const position = useUpdatePosition(editor, selectionRef)
+
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
@@ -62,57 +65,6 @@ export default function AutoModifyMenu({
   const handleBadFeedbackClick = () => {
     setIsShowFeedbackMenu(true)
   }
-
-  // MEMO(Sohyun): 텍스트 에디터에서 특정 영역을 선택했을 때, 그 선택 영역 기준으로 메뉴 UI를 띄우기 위한 좌표 계산
-  // BubbleMenu는 에디터 내용 변경 시 초기화되는 문제로 직접 좌표를 계산한 UI를 구현함
-  //  선택 영역의 위치를 계산하는 함수
-  const updatePosition = () => {
-    if (!editor || !selectionRef?.current) return
-
-    const { to } = selectionRef.current
-    const view = editor.view
-
-    try {
-      // 선택된 텍스트의 마지막 위치(to)에서 해당 위치의 좌표를 구함
-      // MEMO(Sohyun): view.coordsAtPos(pos)는 에디터 문서 내 특정 문자 인덱스(pos)에 해당하는 브라우저 상의 실제 좌표를 반환하는 Prosemirror API
-      // (참고) https://prosemirror.net/docs/ref/#view.EditorView.coordsAtPos
-      const endCoords = view.coordsAtPos(to)
-
-      // 에디터 요소의 위치 정보 가져오기
-      const editorRect = editor.view.dom.getBoundingClientRect()
-
-      // 스크롤 위치를 고려한 절대 위치 계산
-      // 뷰포트 기준 좌표(endCoords)에 스크롤 위치를 더하지 않음 (coordsAtPos는 이미 viewport 기준 좌표 반환)
-      setPosition({
-        top: endCoords.bottom,
-        left: Math.max(editorRect.left + 20, endCoords.left),
-      })
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
-  // 초기 위치 설정
-  useEffect(() => {
-    updatePosition()
-  }, [editor, selectionRef, isVisible])
-
-  // 스크롤 이벤트 리스너 등록 > 스크롤시에도 메뉴가 드래그한 위치 아래에 고정되도록
-  useEffect(() => {
-    const handleScroll = () => {
-      updatePosition()
-    }
-    // 에디터 컨테이너 또는 상위 요소에 스크롤 이벤트 리스너 추가
-    const editorDOM = editor?.view.dom
-    const editorContainer = editorDOM?.closest('.tiptap') || window
-    editorContainer.addEventListener('scroll', handleScroll)
-    // window.addEventListener('scroll', handleScroll) // 전체 페이지 스크롤도 감지
-
-    return () => {
-      editorContainer.removeEventListener('scroll', handleScroll)
-      window.removeEventListener('scroll', handleScroll)
-    }
-  }, [editor, selectionRef])
 
   if (!isVisible) return null
 

--- a/src/app/components/editor/ai-assistant-interface/AutoModifyMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/AutoModifyMenu.tsx
@@ -65,31 +65,54 @@ export default function AutoModifyMenu({
 
   // MEMO(Sohyun): 텍스트 에디터에서 특정 영역을 선택했을 때, 그 선택 영역 기준으로 메뉴 UI를 띄우기 위한 좌표 계산
   // BubbleMenu는 에디터 내용 변경 시 초기화되는 문제로 직접 좌표를 계산한 UI를 구현함
-  useEffect(() => {
-    if (!isVisible || !editor || !selectionRef?.current) return
+  //  선택 영역의 위치를 계산하는 함수
+  const updatePosition = () => {
+    if (!editor || !selectionRef?.current) return
 
-    // 선택 범위의 좌표 계산
-    const { from, to } = selectionRef?.current
+    const { to } = selectionRef.current
     const view = editor.view
 
     try {
+      // 선택된 텍스트의 마지막 위치(to)에서 해당 위치의 좌표를 구함
       // MEMO(Sohyun): view.coordsAtPos(pos)는 에디터 문서 내 특정 문자 인덱스(pos)에 해당하는 브라우저 상의 실제 좌표를 반환하는 Prosemirror API
       // (참고) https://prosemirror.net/docs/ref/#view.EditorView.coordsAtPos
-      const startCoords = view.coordsAtPos(from)
       const endCoords = view.coordsAtPos(to)
 
-      // 선택된 영역의 가로 중앙 위치 계산
-      const centerX = (startCoords.left + endCoords.left) / 2
+      // 에디터 요소의 위치 정보 가져오기
+      const editorRect = editor.view.dom.getBoundingClientRect()
 
-      // 텍스트 아래 여백(8px)을 두고, 가운데 정렬로 배치
+      // 스크롤 위치를 고려한 절대 위치 계산
+      // 뷰포트 기준 좌표(endCoords)에 스크롤 위치를 더하지 않음 (coordsAtPos는 이미 viewport 기준 좌표 반환)
       setPosition({
-        top: endCoords.bottom + 8,
-        left: centerX,
+        top: endCoords.bottom,
+        left: Math.max(editorRect.left + 20, endCoords.left),
       })
     } catch (error) {
       console.error(error)
     }
+  }
+
+  // 초기 위치 설정
+  useEffect(() => {
+    updatePosition()
   }, [editor, selectionRef, isVisible])
+
+  // 스크롤 이벤트 리스너 등록 > 스크롤시에도 메뉴가 드래그한 위치 아래에 고정되도록
+  useEffect(() => {
+    const handleScroll = () => {
+      updatePosition()
+    }
+    // 에디터 컨테이너 또는 상위 요소에 스크롤 이벤트 리스너 추가
+    const editorDOM = editor?.view.dom
+    const editorContainer = editorDOM?.closest('.tiptap') || window
+    editorContainer.addEventListener('scroll', handleScroll)
+    // window.addEventListener('scroll', handleScroll) // 전체 페이지 스크롤도 감지
+
+    return () => {
+      editorContainer.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [editor, selectionRef])
 
   if (!isVisible) return null
 
@@ -100,10 +123,9 @@ export default function AutoModifyMenu({
         // 스타일 위치를 동적으로 계산해야 하므로 인라인 스타일 적용
         style={{
           width: 200,
-          position: 'absolute',
+          position: 'fixed',
           top: `${position.top}px`,
           left: `${position.left}px`,
-          transform: 'translateX(-50%)',
           zIndex: 100,
         }}
       >

--- a/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
@@ -63,27 +63,40 @@ export default function FeedbackMenu({
     setIsShowFeedbackMenu(true)
   }
 
-  useEffect(() => {
+  const updatePosition = () => {
     if (!editor || !selectionRef?.current) return
 
-    // 선택 범위의 좌표 계산
-    const { from, to } = selectionRef?.current
+    const { to } = selectionRef.current
     const view = editor.view
 
     try {
-      const startCoords = view.coordsAtPos(from)
       const endCoords = view.coordsAtPos(to)
-
-      // 선택된 영역의 가로 중앙 위치 계산
-      const centerX = (startCoords.left + endCoords.left) / 2
-
-      // 텍스트 아래 여백(8px)을 두고, 가운데 정렬로 배치
+      const editorRect = editor.view.dom.getBoundingClientRect()
       setPosition({
-        top: endCoords.bottom + 8,
-        left: centerX,
+        top: endCoords.bottom,
+        left: Math.max(editorRect.left + 20, endCoords.left),
       })
     } catch (error) {
       console.error(error)
+    }
+  }
+
+  useEffect(() => {
+    updatePosition()
+  }, [editor, selectionRef])
+
+  useEffect(() => {
+    const handleScroll = () => {
+      updatePosition()
+    }
+    const editorDOM = editor?.view.dom
+    const editorContainer = editorDOM?.closest('.tiptap') || window
+    editorContainer.addEventListener('scroll', handleScroll)
+    // window.addEventListener('scroll', handleScroll) // 전체 페이지 스크롤도 감지
+
+    return () => {
+      editorContainer.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('scroll', handleScroll)
     }
   }, [editor, selectionRef])
 
@@ -92,7 +105,7 @@ export default function FeedbackMenu({
       <div
         style={{
           width: 200,
-          position: 'absolute',
+          position: 'fixed',
           top: `${position.top}px`,
           left: `${position.left}px`,
           transform: 'translateX(-50%)',

--- a/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
@@ -1,7 +1,10 @@
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, RefObject, useEffect, useState } from 'react'
 
+import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
-import { ActionOptionType, EvaluateStateType } from 'types/common/editor'
+import { ActionOptionType, EvaluateStateType, TextSelectionRangeType } from 'types/common/editor'
+
+import Portal from '@components/modal/Portal'
 
 import FeedbackOptionMenu from './menu/FeedbackOptionMenu'
 import PrimaryActionMenu from './menu/PrimaryActionMenu'
@@ -9,6 +12,8 @@ import PrimaryActionMenu from './menu/PrimaryActionMenu'
 import styles from '../DefaultEditor.module.scss'
 
 interface FeedbackMenuProps {
+  editor: Editor
+  selectionRef: RefObject<TextSelectionRangeType | null>
   feedbackText: string | null
   onOptionClick: (option: ActionOptionType) => () => void
   feedback: EvaluateStateType
@@ -18,10 +23,13 @@ interface FeedbackMenuProps {
 // MEMO(Sohyun): ai-assistant 인터페이스 구간 피드백 UI
 export default function FeedbackMenu({
   feedback,
+  editor,
+  selectionRef,
   feedbackText,
   onOptionClick,
   handleSubmitFeedback,
 }: FeedbackMenuProps) {
+  const [position, setPosition] = useState({ top: 0, left: 0 })
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
@@ -55,34 +63,69 @@ export default function FeedbackMenu({
     setIsShowFeedbackMenu(true)
   }
 
-  return (
-    <div>
-      <div className={styles['prompt-menu']}>
-        <input
-          readOnly
-          className={styles['prompt-menu__input']}
-          value={feedbackText ? feedbackText : '선택한 구간에 대한 피드백을 생성하고 있어요.'}
-        />
-      </div>
+  useEffect(() => {
+    if (!editor || !selectionRef?.current) return
 
-      <div className={styles['select-menu']}>
-        {isShowFeedbackMenu ? (
-          <FeedbackOptionMenu
-            onSubmitFeedback={onSubmitFeedback}
-            isShowFeedbackInput={isShowFeedbackInput}
-            setIsShowFeedbackInput={setIsShowFeedbackInput}
-            feedbackInput={feedbackInput}
-            onFeedbackInputChange={handleChange}
+    // 선택 범위의 좌표 계산
+    const { from, to } = selectionRef?.current
+    const view = editor.view
+
+    try {
+      const startCoords = view.coordsAtPos(from)
+      const endCoords = view.coordsAtPos(to)
+
+      // 선택된 영역의 가로 중앙 위치 계산
+      const centerX = (startCoords.left + endCoords.left) / 2
+
+      // 텍스트 아래 여백(8px)을 두고, 가운데 정렬로 배치
+      setPosition({
+        top: endCoords.bottom + 8,
+        left: centerX,
+      })
+    } catch (error) {
+      console.error(error)
+    }
+  }, [editor, selectionRef])
+
+  return (
+    <Portal>
+      <div
+        style={{
+          width: 200,
+          position: 'absolute',
+          top: `${position.top}px`,
+          left: `${position.left}px`,
+          transform: 'translateX(-50%)',
+          zIndex: 100,
+        }}
+      >
+        <div className={styles['prompt-menu']}>
+          <input
+            readOnly
+            className={styles['prompt-menu__input']}
+            value={feedbackText ? feedbackText : '선택한 구간에 대한 피드백을 생성하고 있어요.'}
           />
-        ) : (
-          <PrimaryActionMenu
-            onOptionClick={onOptionClick}
-            feedback={feedback}
-            onFeedbackClick={handleFeedbackClick}
-            onBadFeedbackClick={handleBadFeedbackClick}
-          />
-        )}
+        </div>
+
+        <div className={styles['select-menu']}>
+          {isShowFeedbackMenu ? (
+            <FeedbackOptionMenu
+              onSubmitFeedback={onSubmitFeedback}
+              isShowFeedbackInput={isShowFeedbackInput}
+              setIsShowFeedbackInput={setIsShowFeedbackInput}
+              feedbackInput={feedbackInput}
+              onFeedbackInputChange={handleChange}
+            />
+          ) : (
+            <PrimaryActionMenu
+              onOptionClick={onOptionClick}
+              feedback={feedback}
+              onFeedbackClick={handleFeedbackClick}
+              onBadFeedbackClick={handleBadFeedbackClick}
+            />
+          )}
+        </div>
       </div>
-    </div>
+    </Portal>
   )
 }

--- a/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
@@ -1,10 +1,12 @@
-import { ChangeEvent, RefObject, useEffect, useState } from 'react'
+import { ChangeEvent, RefObject, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
 import { ActionOptionType, EvaluateStateType, TextSelectionRangeType } from 'types/common/editor'
 
 import Portal from '@components/modal/Portal'
+
+import useUpdatePosition from '@hooks/editor/useUpdatePosition'
 
 import FeedbackOptionMenu from './menu/FeedbackOptionMenu'
 import PrimaryActionMenu from './menu/PrimaryActionMenu'
@@ -29,7 +31,8 @@ export default function FeedbackMenu({
   onOptionClick,
   handleSubmitFeedback,
 }: FeedbackMenuProps) {
-  const [position, setPosition] = useState({ top: 0, left: 0 })
+  const position = useUpdatePosition(editor, selectionRef)
+
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
@@ -63,43 +66,6 @@ export default function FeedbackMenu({
     setIsShowFeedbackMenu(true)
   }
 
-  const updatePosition = () => {
-    if (!editor || !selectionRef?.current) return
-
-    const { to } = selectionRef.current
-    const view = editor.view
-
-    try {
-      const endCoords = view.coordsAtPos(to)
-      const editorRect = editor.view.dom.getBoundingClientRect()
-      setPosition({
-        top: endCoords.bottom,
-        left: Math.max(editorRect.left + 20, endCoords.left),
-      })
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
-  useEffect(() => {
-    updatePosition()
-  }, [editor, selectionRef])
-
-  useEffect(() => {
-    const handleScroll = () => {
-      updatePosition()
-    }
-    const editorDOM = editor?.view.dom
-    const editorContainer = editorDOM?.closest('.tiptap') || window
-    editorContainer.addEventListener('scroll', handleScroll)
-    // window.addEventListener('scroll', handleScroll) // 전체 페이지 스크롤도 감지
-
-    return () => {
-      editorContainer.removeEventListener('scroll', handleScroll)
-      window.removeEventListener('scroll', handleScroll)
-    }
-  }, [editor, selectionRef])
-
   return (
     <Portal>
       <div
@@ -108,7 +74,6 @@ export default function FeedbackMenu({
           position: 'fixed',
           top: `${position.top}px`,
           left: `${position.left}px`,
-          transform: 'translateX(-50%)',
           zIndex: 100,
         }}
       >

--- a/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
@@ -12,6 +12,7 @@ import FeedbackOptionMenu from './menu/FeedbackOptionMenu'
 import PrimaryActionMenu from './menu/PrimaryActionMenu'
 
 import styles from '../DefaultEditor.module.scss'
+import promptStyles from '../common/PromptInput.module.scss'
 
 interface FeedbackMenuProps {
   editor: Editor
@@ -88,12 +89,13 @@ export default function FeedbackMenu({
           zIndex: 100,
         }}
       >
-        <div className={styles['prompt-menu']}>
+        {/* TODO 공통 컴포넌트 PromptInput을 사용하기 */}
+        <div className={promptStyles['prompt-menu']}>
           <textarea
             ref={textareaRef}
             readOnly
             value={feedbackText ? feedbackText : '선택한 구간에 대한 피드백을 생성하고 있어요.'}
-            className={styles['prompt-menu__input']}
+            className={promptStyles['prompt-menu__input']}
           />
         </div>
 

--- a/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
@@ -19,6 +19,7 @@ interface FeedbackMenuProps {
   feedbackText: string | null
   onOptionClick: (option: ActionOptionType) => () => void
   feedback: EvaluateStateType
+  isFeedbackPromptMenuOpen: boolean
   handleSubmitFeedback: ({ isGood, feedback, feedbackType }: FeedbackFormData) => void
 }
 
@@ -29,6 +30,7 @@ export default function FeedbackMenu({
   selectionRef,
   feedbackText,
   onOptionClick,
+  isFeedbackPromptMenuOpen,
   handleSubmitFeedback,
 }: FeedbackMenuProps) {
   const position = useUpdatePosition(editor, selectionRef)
@@ -95,25 +97,26 @@ export default function FeedbackMenu({
           />
         </div>
 
-        {/* TODO 구간피드백 생성후에 메뉴 노출 */}
-        <div className={styles['select-menu']}>
-          {isShowFeedbackMenu ? (
-            <FeedbackOptionMenu
-              onSubmitFeedback={onSubmitFeedback}
-              isShowFeedbackInput={isShowFeedbackInput}
-              setIsShowFeedbackInput={setIsShowFeedbackInput}
-              feedbackInput={feedbackInput}
-              onFeedbackInputChange={handleChange}
-            />
-          ) : (
-            <PrimaryActionMenu
-              onOptionClick={onOptionClick}
-              feedback={feedback}
-              onFeedbackClick={handleFeedbackClick}
-              onBadFeedbackClick={handleBadFeedbackClick}
-            />
-          )}
-        </div>
+        {isFeedbackPromptMenuOpen && (
+          <div className={styles['select-menu']}>
+            {isShowFeedbackMenu ? (
+              <FeedbackOptionMenu
+                onSubmitFeedback={onSubmitFeedback}
+                isShowFeedbackInput={isShowFeedbackInput}
+                setIsShowFeedbackInput={setIsShowFeedbackInput}
+                feedbackInput={feedbackInput}
+                onFeedbackInputChange={handleChange}
+              />
+            ) : (
+              <PrimaryActionMenu
+                onOptionClick={onOptionClick}
+                feedback={feedback}
+                onFeedbackClick={handleFeedbackClick}
+                onBadFeedbackClick={handleBadFeedbackClick}
+              />
+            )}
+          </div>
+        )}
       </div>
     </Portal>
   )

--- a/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/FeedbackMenu.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, RefObject, useState } from 'react'
+import { ChangeEvent, RefObject, useEffect, useRef, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
@@ -32,7 +32,7 @@ export default function FeedbackMenu({
   handleSubmitFeedback,
 }: FeedbackMenuProps) {
   const position = useUpdatePosition(editor, selectionRef)
-
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
@@ -66,6 +66,15 @@ export default function FeedbackMenu({
     setIsShowFeedbackMenu(true)
   }
 
+  // textarea 높이 자동 조절
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${textarea.scrollHeight}px`
+    }
+  }, [feedbackText])
+
   return (
     <Portal>
       <div
@@ -78,13 +87,15 @@ export default function FeedbackMenu({
         }}
       >
         <div className={styles['prompt-menu']}>
-          <input
+          <textarea
+            ref={textareaRef}
             readOnly
-            className={styles['prompt-menu__input']}
             value={feedbackText ? feedbackText : '선택한 구간에 대한 피드백을 생성하고 있어요.'}
+            className={styles['prompt-menu__input']}
           />
         </div>
 
+        {/* TODO 구간피드백 생성후에 메뉴 노출 */}
         <div className={styles['select-menu']}>
           {isShowFeedbackMenu ? (
             <FeedbackOptionMenu

--- a/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
+++ b/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
@@ -15,8 +15,6 @@ import styles from '../DefaultEditor.module.scss'
 interface ManualModificationProps {
   editor: Editor
   selectionRef: RefObject<TextSelectionRangeType | null>
-  isOpen: boolean
-  onClose: () => void
   onPromptChange: (value: string) => void
   onAiPrompt: () => void
   onOptionClick: (option: ActionOptionType) => () => void

--- a/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
+++ b/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
@@ -1,9 +1,11 @@
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, RefObject, useEffect, useState } from 'react'
 
+import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
-import { ActionOptionType, EvaluateStateType } from 'types/common/editor'
+import { ActionOptionType, EvaluateStateType, TextSelectionRangeType } from 'types/common/editor'
 
 import FillButton from '@components/buttons/FillButton'
+import Portal from '@components/modal/Portal'
 
 import FeedbackOptionMenu from './menu/FeedbackOptionMenu'
 import PrimaryActionMenu from './menu/PrimaryActionMenu'
@@ -11,6 +13,8 @@ import PrimaryActionMenu from './menu/PrimaryActionMenu'
 import styles from '../DefaultEditor.module.scss'
 
 interface ManualModificationProps {
+  editor: Editor
+  selectionRef: RefObject<TextSelectionRangeType | null>
   isOpen: boolean
   onClose: () => void
   onPromptChange: (value: string) => void
@@ -23,11 +27,14 @@ interface ManualModificationProps {
 // MEMO(Sohyun): ai-assistant 인터페이스 수동 수정 UI
 export default function ManualModification({
   feedback,
+  editor,
+  selectionRef,
   onPromptChange,
   onAiPrompt,
   onOptionClick,
   handleSubmitFeedback,
 }: ManualModificationProps) {
+  const [position, setPosition] = useState({ top: 0, left: 0 })
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
@@ -64,9 +71,42 @@ export default function ManualModification({
     setIsShowFeedbackMenu(true)
   }
 
+  useEffect(() => {
+    if (!editor || !selectionRef?.current) return
+
+    // 선택 범위의 좌표 계산
+    const { from, to } = selectionRef?.current
+    const view = editor.view
+
+    try {
+      const startCoords = view.coordsAtPos(from)
+      const endCoords = view.coordsAtPos(to)
+
+      // 선택된 영역의 가로 중앙 위치 계산
+      const centerX = (startCoords.left + endCoords.left) / 2
+
+      // 텍스트 아래 여백(8px)을 두고, 가운데 정렬로 배치
+      setPosition({
+        top: endCoords.bottom + 8,
+        left: centerX,
+      })
+    } catch (error) {
+      console.error(error)
+    }
+  }, [editor, selectionRef])
+
   return (
-    <>
-      <div className={styles.container}>
+    <Portal>
+      <div
+        style={{
+          width: 200,
+          position: 'absolute',
+          top: `${position.top}px`,
+          left: `${position.left}px`,
+          transform: 'translateX(-50%)',
+          zIndex: 100,
+        }}
+      >
         <div className={styles['prompt-menu']}>
           <input
             autoFocus
@@ -106,6 +146,6 @@ export default function ManualModification({
           )}
         </div>
       </div>
-    </>
+    </Portal>
   )
 }

--- a/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
+++ b/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, RefObject, useEffect, useState } from 'react'
+import { ChangeEvent, RefObject, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
@@ -6,6 +6,8 @@ import { ActionOptionType, EvaluateStateType, TextSelectionRangeType } from 'typ
 
 import FillButton from '@components/buttons/FillButton'
 import Portal from '@components/modal/Portal'
+
+import useUpdatePosition from '@hooks/editor/useUpdatePosition'
 
 import FeedbackOptionMenu from './menu/FeedbackOptionMenu'
 import PrimaryActionMenu from './menu/PrimaryActionMenu'
@@ -32,7 +34,8 @@ export default function ManualModification({
   onOptionClick,
   handleSubmitFeedback,
 }: ManualModificationProps) {
-  const [position, setPosition] = useState({ top: 0, left: 0 })
+  const position = useUpdatePosition(editor, selectionRef)
+
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
@@ -68,44 +71,6 @@ export default function ManualModification({
   const handleBadFeedbackClick = () => {
     setIsShowFeedbackMenu(true)
   }
-
-  const updatePosition = () => {
-    if (!editor || !selectionRef?.current) return
-
-    const { to } = selectionRef.current
-    const view = editor.view
-
-    try {
-      const endCoords = view.coordsAtPos(to)
-      const editorRect = editor.view.dom.getBoundingClientRect()
-      setPosition({
-        top: endCoords.bottom,
-        left: Math.max(editorRect.left, endCoords.left),
-      })
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
-  useEffect(() => {
-    updatePosition()
-  }, [editor, selectionRef])
-
-  useEffect(() => {
-    const handleScroll = () => {
-      updatePosition()
-    }
-
-    const editorDOM = editor?.view.dom
-    const editorContainer = editorDOM?.closest('.tiptap') || window
-    editorContainer.addEventListener('scroll', handleScroll)
-    window.addEventListener('scroll', handleScroll) // 전체 페이지 스크롤도 감지
-
-    return () => {
-      editorContainer.removeEventListener('scroll', handleScroll)
-      window.removeEventListener('scroll', handleScroll)
-    }
-  }, [editor, selectionRef])
 
   return (
     <Portal>

--- a/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
+++ b/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
@@ -69,27 +69,41 @@ export default function ManualModification({
     setIsShowFeedbackMenu(true)
   }
 
-  useEffect(() => {
+  const updatePosition = () => {
     if (!editor || !selectionRef?.current) return
 
-    // 선택 범위의 좌표 계산
-    const { from, to } = selectionRef?.current
+    const { to } = selectionRef.current
     const view = editor.view
 
     try {
-      const startCoords = view.coordsAtPos(from)
       const endCoords = view.coordsAtPos(to)
-
-      // 선택된 영역의 가로 중앙 위치 계산
-      const centerX = (startCoords.left + endCoords.left) / 2
-
-      // 텍스트 아래 여백(8px)을 두고, 가운데 정렬로 배치
+      const editorRect = editor.view.dom.getBoundingClientRect()
       setPosition({
-        top: endCoords.bottom + 8,
-        left: centerX,
+        top: endCoords.bottom,
+        left: Math.max(editorRect.left, endCoords.left),
       })
     } catch (error) {
       console.error(error)
+    }
+  }
+
+  useEffect(() => {
+    updatePosition()
+  }, [editor, selectionRef])
+
+  useEffect(() => {
+    const handleScroll = () => {
+      updatePosition()
+    }
+
+    const editorDOM = editor?.view.dom
+    const editorContainer = editorDOM?.closest('.tiptap') || window
+    editorContainer.addEventListener('scroll', handleScroll)
+    window.addEventListener('scroll', handleScroll) // 전체 페이지 스크롤도 감지
+
+    return () => {
+      editorContainer.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('scroll', handleScroll)
     }
   }, [editor, selectionRef])
 
@@ -98,10 +112,9 @@ export default function ManualModification({
       <div
         style={{
           width: 200,
-          position: 'absolute',
+          position: 'fixed',
           top: `${position.top}px`,
           left: `${position.left}px`,
-          transform: 'translateX(-50%)',
           zIndex: 100,
         }}
       >

--- a/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
+++ b/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, RefObject, useState } from 'react'
+import { ChangeEvent, RefObject, useRef, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
@@ -37,13 +37,23 @@ export default function ManualModification({
   handleSubmitFeedback,
 }: ManualModificationProps) {
   const position = useUpdatePosition(editor, selectionRef)
-
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  // TODO 공통 함수로 분리
+  const adjustTextareaHeight = () => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${textarea.scrollHeight}px`
+    }
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     onPromptChange(e.target.value)
+    adjustTextareaHeight()
   }
 
   const handleChangeFeedbackInput = (e: ChangeEvent<HTMLInputElement>) => {
@@ -86,11 +96,14 @@ export default function ManualModification({
         }}
       >
         <div className={styles['prompt-menu']}>
-          <input
+          <textarea
             autoFocus
             className={styles['prompt-menu__input']}
-            onChange={handleChange}
             placeholder="프롬프트를 입력해 주세요."
+            ref={textareaRef}
+            onChange={handleChange}
+            rows={1}
+            style={{ overflow: 'hidden' }}
           />
           <FillButton
             size="medium"

--- a/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
+++ b/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
@@ -15,6 +15,7 @@ import PrimaryActionMenu from './menu/PrimaryActionMenu'
 import styles from '../DefaultEditor.module.scss'
 
 interface ManualModificationProps {
+  isPrimaryActionMenuOpen: boolean
   editor: Editor
   selectionRef: RefObject<TextSelectionRangeType | null>
   onPromptChange: (value: string) => void
@@ -26,6 +27,7 @@ interface ManualModificationProps {
 
 // MEMO(Sohyun): ai-assistant 인터페이스 수동 수정 UI
 export default function ManualModification({
+  isPrimaryActionMenuOpen,
   feedback,
   editor,
   selectionRef,
@@ -103,24 +105,26 @@ export default function ManualModification({
           </FillButton>
         </div>
 
-        <div className={styles['select-menu']}>
-          {isShowFeedbackMenu ? (
-            <FeedbackOptionMenu
-              onSubmitFeedback={onSubmitFeedback}
-              isShowFeedbackInput={isShowFeedbackInput}
-              setIsShowFeedbackInput={setIsShowFeedbackInput}
-              feedbackInput={feedbackInput}
-              onFeedbackInputChange={handleChangeFeedbackInput}
-            />
-          ) : (
-            <PrimaryActionMenu
-              onOptionClick={onOptionClick}
-              feedback={feedback}
-              onFeedbackClick={handleFeedbackClick}
-              onBadFeedbackClick={handleBadFeedbackClick}
-            />
-          )}
-        </div>
+        {isPrimaryActionMenuOpen && (
+          <div className={styles['select-menu']}>
+            {isShowFeedbackMenu ? (
+              <FeedbackOptionMenu
+                onSubmitFeedback={onSubmitFeedback}
+                isShowFeedbackInput={isShowFeedbackInput}
+                setIsShowFeedbackInput={setIsShowFeedbackInput}
+                feedbackInput={feedbackInput}
+                onFeedbackInputChange={handleChangeFeedbackInput}
+              />
+            ) : (
+              <PrimaryActionMenu
+                onOptionClick={onOptionClick}
+                feedback={feedback}
+                onFeedbackClick={handleFeedbackClick}
+                onBadFeedbackClick={handleBadFeedbackClick}
+              />
+            )}
+          </div>
+        )}
       </div>
     </Portal>
   )

--- a/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
+++ b/src/app/components/editor/ai-assistant-interface/ManualModification.tsx
@@ -1,14 +1,14 @@
-import { ChangeEvent, RefObject, useRef, useState } from 'react'
+import { ChangeEvent, RefObject, useState } from 'react'
 
 import { Editor } from '@tiptap/react'
 import { FeedbackFormData, FeedbackOptionType } from 'types/chatbot/chatbot'
 import { ActionOptionType, EvaluateStateType, TextSelectionRangeType } from 'types/common/editor'
 
-import FillButton from '@components/buttons/FillButton'
 import Portal from '@components/modal/Portal'
 
 import useUpdatePosition from '@hooks/editor/useUpdatePosition'
 
+import PromptInput from '../common/PromptInput'
 import FeedbackOptionMenu from './menu/FeedbackOptionMenu'
 import PrimaryActionMenu from './menu/PrimaryActionMenu'
 
@@ -37,23 +37,12 @@ export default function ManualModification({
   handleSubmitFeedback,
 }: ManualModificationProps) {
   const position = useUpdatePosition(editor, selectionRef)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [feedbackInput, setFeedbackInput] = useState('')
   const [isShowFeedbackMenu, setIsShowFeedbackMenu] = useState(false)
   const [isShowFeedbackInput, setIsShowFeedbackInput] = useState(false)
 
-  // TODO 공통 함수로 분리
-  const adjustTextareaHeight = () => {
-    const textarea = textareaRef.current
-    if (textarea) {
-      textarea.style.height = 'auto'
-      textarea.style.height = `${textarea.scrollHeight}px`
-    }
-  }
-
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     onPromptChange(e.target.value)
-    adjustTextareaHeight()
   }
 
   const handleChangeFeedbackInput = (e: ChangeEvent<HTMLInputElement>) => {
@@ -95,28 +84,12 @@ export default function ManualModification({
           zIndex: 100,
         }}
       >
-        <div className={styles['prompt-menu']}>
-          <textarea
-            autoFocus
-            className={styles['prompt-menu__input']}
-            placeholder="프롬프트를 입력해 주세요."
-            ref={textareaRef}
-            onChange={handleChange}
-            rows={1}
-            style={{ overflow: 'hidden' }}
-          />
-          <FillButton
-            size="medium"
-            variant="primary"
-            style={{
-              padding: '0.8rem 1.2rem',
-              height: '100%',
-            }}
-            onClick={onAiPrompt}
-          >
-            생성하기
-          </FillButton>
-        </div>
+        <PromptInput
+          onPromptInputChange={handleChange}
+          onSubmit={onAiPrompt}
+          placeholder="프롬프트를 입력해 주세요."
+          buttonText="생성하기"
+        />
 
         {isPrimaryActionMenuOpen && (
           <div className={styles['select-menu']}>

--- a/src/app/components/editor/common/PromptInput.module.scss
+++ b/src/app/components/editor/common/PromptInput.module.scss
@@ -1,0 +1,31 @@
+@use '@styles/typography';
+@use '@styles/colors' as color;
+@use '@styles/mixins' as mixin;
+
+.prompt-menu {
+  width: 462px;
+  min-height: 52px;
+
+  padding: 0.8rem;
+  padding-left: 1.6rem;
+
+  @include mixin.flex(row, center, space-between);
+  gap: 1.6rem;
+
+  border-radius: 1.2rem;
+  background: color.$alert-secondary-0;
+  box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.1);
+
+  &__input {
+    flex: 1;
+    height: 17px;
+
+    @extend %typo-body-medium;
+    color: color.$core-secondary-100;
+
+    border: none;
+    outline: none;
+    resize: none;
+    cursor: default;
+  }
+}

--- a/src/app/components/editor/common/PromptInput.tsx
+++ b/src/app/components/editor/common/PromptInput.tsx
@@ -1,0 +1,73 @@
+import { ChangeEvent, useEffect, useRef } from 'react'
+
+import FillButton from '@components/buttons/FillButton'
+
+import styles from './PromptInput.module.scss'
+
+interface PromptInputProps {
+  onPromptInputChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
+  onSubmit: () => void
+  placeholder?: string
+  buttonText?: string
+  initialValue?: string
+  hasButton?: boolean
+}
+
+/**
+ * 수동 수정 prompt, 메모 입력 prompt, 구간 피드백 prompt(예정)에서 사용하는 textarea공통 컴포넌트
+ */
+export default function PromptInput({
+  onPromptInputChange,
+  onSubmit,
+  placeholder,
+  buttonText,
+  hasButton = true,
+}: PromptInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // textarea 높이 자동 조절 함수
+  const adjustTextareaHeight = () => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${textarea.scrollHeight}px`
+    }
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    onPromptInputChange(e)
+    adjustTextareaHeight()
+  }
+
+  useEffect(() => {
+    adjustTextareaHeight()
+  }, [])
+
+  return (
+    <div className={styles['prompt-menu']}>
+      <textarea
+        readOnly={!hasButton}
+        autoFocus
+        className={styles['prompt-menu__input']}
+        ref={textareaRef}
+        placeholder={placeholder}
+        onChange={handleChange}
+        rows={1}
+        style={{ overflow: 'hidden' }}
+      />
+      {hasButton && (
+        <FillButton
+          size="medium"
+          variant="primary"
+          style={{
+            padding: '0.8rem 1.2rem',
+            height: '100%',
+          }}
+          onClick={onSubmit}
+        >
+          {buttonText}
+        </FillButton>
+      )}
+    </div>
+  )
+}

--- a/src/app/components/pdfExportPreview/PdfExportPreview.module.scss
+++ b/src/app/components/pdfExportPreview/PdfExportPreview.module.scss
@@ -19,4 +19,9 @@
     margin: 1.6rem 0;
     padding-left: 1.6rem;
   }
+
+  mark {
+    border-bottom: initial !important;
+    background-color: transparent !important;
+  }
 }

--- a/src/app/components/toast/Toast.tsx
+++ b/src/app/components/toast/Toast.tsx
@@ -23,7 +23,7 @@ export function Toast({ type, message, onClose }: ToastProps) {
   }, [onClose])
 
   return (
-    <div className={cx('toast-wrapper')} style={{ zIndex: 10 }}>
+    <div className={cx('toast-wrapper')} style={{ zIndex: 300 }}>
       <div className={cx('toast')}>
         {type === 'success' ? (
           <FaCircleCheck size={20} color="#20ACE8" />

--- a/src/app/hooks/editor/useMemos.tsx
+++ b/src/app/hooks/editor/useMemos.tsx
@@ -21,7 +21,7 @@ export function useMemos(editor: Editor | null) {
 
   const savedMemosMutation = useSavedMemos()
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setContent(e.target.value)
   }
 

--- a/src/app/hooks/editor/useMemos.tsx
+++ b/src/app/hooks/editor/useMemos.tsx
@@ -40,7 +40,7 @@ export function useMemos(editor: Editor | null) {
       {
         productId,
         data: {
-          title: selectedText,
+          title: '',
           content,
           selectedText,
           startIndex: from,

--- a/src/app/hooks/editor/useTextEditor.tsx
+++ b/src/app/hooks/editor/useTextEditor.tsx
@@ -48,7 +48,6 @@ export function useTextEditor(editor: Editor | null) {
   const showToast = useToast()
 
   const { isOpen, onOpen, onClose } = useCollapsed()
-  const { onOpen: onOpenFeedback, onClose: onCloseFeedback } = useCollapsed()
   const {
     isOpen: isAutoModifyVisible,
     onOpen: onOpenAutoModifyVisible,
@@ -232,7 +231,6 @@ export function useTextEditor(editor: Editor | null) {
         setFeedback(INITIAL_EVALUATE_STATE)
         // TODO 로딩중일때
         feedbackInput.current = response.answer
-        onOpenFeedback()
       }
     } catch (error) {
       console.log(error)
@@ -307,7 +305,6 @@ export function useTextEditor(editor: Editor | null) {
         }
         onClose()
         feedbackInput.current = null
-        onCloseFeedback()
         break
 
       case 'archive':
@@ -332,7 +329,6 @@ export function useTextEditor(editor: Editor | null) {
           setAiResult(feedbackInput.current)
         }
         feedbackInput.current = null
-        onCloseFeedback()
         break
 
       case 'recreate':
@@ -349,7 +345,6 @@ export function useTextEditor(editor: Editor | null) {
           originalSelectionRef.current = null
         }
         feedbackInput.current = null
-        onCloseFeedback()
         break
 
       case 'archive':

--- a/src/app/hooks/editor/useTextEditor.tsx
+++ b/src/app/hooks/editor/useTextEditor.tsx
@@ -47,8 +47,7 @@ export function useTextEditor(editor: Editor | null) {
 
   const showToast = useToast()
 
-  // TODO PrimaryActionMenu이 setAiResult 후 나타나야함
-  const { onOpen, onClose } = useCollapsed()
+  const { isOpen, onOpen, onClose } = useCollapsed()
   const { onOpen: onOpenFeedback, onClose: onCloseFeedback } = useCollapsed()
   const {
     isOpen: isAutoModifyVisible,
@@ -385,6 +384,7 @@ export function useTextEditor(editor: Editor | null) {
   }, [editor?.state.selection.empty])
 
   return {
+    isOpen,
     feedback,
     activeMenu,
     feedbackInput,

--- a/src/app/hooks/editor/useTextEditor.tsx
+++ b/src/app/hooks/editor/useTextEditor.tsx
@@ -49,6 +49,11 @@ export function useTextEditor(editor: Editor | null) {
 
   const { isOpen, onOpen, onClose } = useCollapsed()
   const {
+    isOpen: feedbackPrompt,
+    onOpen: onOpenFeedbackPrompt,
+    onClose: onCloseFeedbackPrompt,
+  } = useCollapsed()
+  const {
     isOpen: isAutoModifyVisible,
     onOpen: onOpenAutoModifyVisible,
     onClose: onCloseAutoModifyVisible,
@@ -188,6 +193,7 @@ export function useTextEditor(editor: Editor | null) {
         onOpenAutoModifyVisible()
       }
     } catch (error) {
+      // TODO 어시스턴트 에러처리 및 로딩처리
       console.log(error)
     }
   }
@@ -231,6 +237,7 @@ export function useTextEditor(editor: Editor | null) {
         setFeedback(INITIAL_EVALUATE_STATE)
         // TODO 로딩중일때
         feedbackInput.current = response.answer
+        onOpenFeedbackPrompt()
       }
     } catch (error) {
       console.log(error)
@@ -322,6 +329,7 @@ export function useTextEditor(editor: Editor | null) {
       case 'apply':
         setActiveMenu('defaultToolbar')
         clearHighlight()
+        onCloseFeedbackPrompt()
 
         // TODO 에디터에 피드백 문구 추출해서 삽입 => 피드백 받은 문구만 api 응답으로 받을 수 있는지 확인하기
         // TODO 구간 피드백 응답이 길어지기 때문에 UI 수정이 필요
@@ -333,6 +341,7 @@ export function useTextEditor(editor: Editor | null) {
 
       case 'recreate':
         handleAiFeedback(originalText)
+        onCloseFeedbackPrompt()
         break
 
       case 'cancel':
@@ -344,6 +353,7 @@ export function useTextEditor(editor: Editor | null) {
           clearHighlight(originalSelectionRef.current)
           originalSelectionRef.current = null
         }
+        onCloseFeedbackPrompt()
         feedbackInput.current = null
         break
 
@@ -380,6 +390,7 @@ export function useTextEditor(editor: Editor | null) {
 
   return {
     isOpen,
+    feedbackPrompt,
     feedback,
     activeMenu,
     feedbackInput,

--- a/src/app/hooks/editor/useTextEditor.tsx
+++ b/src/app/hooks/editor/useTextEditor.tsx
@@ -175,6 +175,7 @@ export function useTextEditor(editor: Editor | null) {
     promptValueRef.current = value
   }
 
+  // TODO(Sohyun) 어시스턴트 에러처리 및 로딩처리 > react-query로 변경
   // 1. 자동 수정
   const handleAiAutoModify = async (originPhrase: string) => {
     if (!selectionRef.current || !editor) return
@@ -193,8 +194,18 @@ export function useTextEditor(editor: Editor | null) {
         onOpenAutoModifyVisible()
       }
     } catch (error) {
-      // TODO 어시스턴트 에러처리 및 로딩처리
       console.log(error)
+      if (selectionRef.current && editor) {
+        editor.commands.insertContentAt(selectionRef.current, originalText)
+      }
+      setActiveMenu('defaultToolbar')
+      if (originalSelectionRef.current) {
+        clearHighlight(originalSelectionRef.current)
+        originalSelectionRef.current = null
+      }
+      onCloseAutoModifyVisible()
+      feedbackInput.current = null
+      showToast('warning', '다시 시도해 주세요')
     }
   }
 
@@ -221,6 +232,17 @@ export function useTextEditor(editor: Editor | null) {
       }
     } catch (error) {
       console.log(error)
+      if (selectionRef.current && editor) {
+        editor.commands.insertContentAt(selectionRef.current, originalText)
+      }
+      setActiveMenu('defaultToolbar')
+      if (originalSelectionRef.current) {
+        clearHighlight(originalSelectionRef.current)
+        originalSelectionRef.current = null
+      }
+      onClose()
+      feedbackInput.current = null
+      showToast('warning', '다시 시도해 주세요')
     }
   }
 
@@ -241,6 +263,17 @@ export function useTextEditor(editor: Editor | null) {
       }
     } catch (error) {
       console.log(error)
+      if (selectionRef.current && editor) {
+        editor.commands.insertContentAt(selectionRef.current, originalText)
+      }
+      setActiveMenu('defaultToolbar')
+      if (originalSelectionRef.current) {
+        clearHighlight(originalSelectionRef.current)
+        originalSelectionRef.current = null
+      }
+      onCloseFeedbackPrompt()
+      feedbackInput.current = null
+      showToast('warning', '다시 시도해 주세요')
     }
   }
 

--- a/src/app/hooks/editor/useTextEditor.tsx
+++ b/src/app/hooks/editor/useTextEditor.tsx
@@ -46,12 +46,10 @@ export function useTextEditor(editor: Editor | null) {
   const feedbackInput = useRef<string | null>(null)
 
   const showToast = useToast()
-  const { isOpen, onOpen, onClose } = useCollapsed()
-  const {
-    isOpen: isFeedbackOpen,
-    onOpen: onOpenFeedback,
-    onClose: onCloseFeedback,
-  } = useCollapsed()
+
+  // TODO PrimaryActionMenu이 setAiResult 후 나타나야함
+  const { onOpen, onClose } = useCollapsed()
+  const { onOpen: onOpenFeedback, onClose: onCloseFeedback } = useCollapsed()
   const {
     isOpen: isAutoModifyVisible,
     onOpen: onOpenAutoModifyVisible,
@@ -389,12 +387,9 @@ export function useTextEditor(editor: Editor | null) {
   return {
     feedback,
     activeMenu,
-    isOpen,
-    onClose,
-    isFeedbackOpen,
+    feedbackInput,
     selectionRef,
     isAutoModifyVisible,
-    feedbackInput,
     handleActiveMenu,
     handlePromptChange,
     handleSubmitFeedback,

--- a/src/app/hooks/editor/useUpdatePosition.ts
+++ b/src/app/hooks/editor/useUpdatePosition.ts
@@ -1,0 +1,82 @@
+import { RefObject, useCallback, useEffect, useState } from 'react'
+
+import { Editor } from '@tiptap/react'
+import { TextSelectionRangeType } from 'types/common/editor'
+
+interface MenuPosition {
+  top: number
+  left: number
+}
+
+/**
+ * 에디터에서 선택한(드래그한) 텍스트 영역 기준으로 ai-assistant 메뉴 위치를 계산하는 훅
+ * MEMO(Sohyun): 텍스트 에디터에서 특정 영역을 선택했을 때, 그 선택 영역 기준으로 메뉴 UI를 띄우기 위한 좌표 계산
+ * BubbleMenu 내부에 위치하면 BubbleMenu는 에디터 내용 변경 시 초기화되는 문제로 직접 좌표를 계산한 UI를 구현하기 위함
+ * @param editor 에디터 인스턴스
+ * @param selectionRef 선택 영역 Ref
+ */
+
+const useUpdatePosition = (
+  editor: Editor,
+  selectionRef: RefObject<TextSelectionRangeType | null>,
+): MenuPosition => {
+  const [position, setPosition] = useState<MenuPosition>({ top: 0, left: 0 })
+
+  // 선택 영역의 위치를 계산하는 함수
+  const updatePosition = useCallback(() => {
+    if (!editor || !selectionRef?.current) return
+
+    const { to } = selectionRef.current
+    const view = editor.view
+
+    try {
+      // 선택된 텍스트의 마지막 위치(to)에서 해당 위치의 좌표를 구함
+      // MEMO(Sohyun): view.coordsAtPos(pos)는 에디터 문서 내 특정 문자 인덱스(pos)에 해당하는 브라우저 상의 실제 좌표를 반환하는 Prosemirror API
+      // (참고) https://prosemirror.net/docs/ref/#view.EditorView.coordsAtPos
+      const endCoords = view.coordsAtPos(to)
+
+      // 에디터 요소의 위치 정보 가져오기
+      const editorRect = editor.view.dom.getBoundingClientRect()
+
+      // 스크롤 위치를 고려한 절대 위치 계산
+      // 뷰포트 기준 좌표(endCoords)에 스크롤 위치를 더하지 않음 (coordsAtPos는 이미 viewport 기준 좌표 반환)
+      setPosition({
+        top: endCoords.bottom,
+        left: Math.max(editorRect.left, endCoords.left),
+      })
+    } catch (error) {
+      console.error(error)
+    }
+  }, [editor, selectionRef])
+
+  // 초기 위치 설정
+  useEffect(() => {
+    updatePosition()
+  }, [editor, updatePosition])
+
+  // 스크롤 이벤트 리스너 등록
+  useEffect(() => {
+    if (!editor) return
+
+    const handleScroll = () => {
+      updatePosition()
+    }
+
+    // 에디터 컨테이너 또는 상위 요소에 스크롤 이벤트 리스너 추가
+    const editorDOM = editor.view.dom
+    const editorContainer = editorDOM?.closest('.tiptap') || editorDOM
+    editorContainer.addEventListener('scroll', handleScroll)
+
+    // 전체 페이지 스크롤 감지 > 그래야 스크롤해도 선택한 구간 밑에 위치가 고정될 수 있음
+    window.addEventListener('scroll', handleScroll)
+
+    return () => {
+      editorContainer.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [editor, updatePosition])
+
+  return position
+}
+
+export default useUpdatePosition


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- 에디터 관련 qa를 해결했습니다.

<br />

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- KAN-156

<br />

> ## 변경 사항
### 관련 이슈
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- [x] [수동 수정 프롬프트 입력창 위치](https://www.notion.so/2038209b09f98051a214e3140b12ac77?source=copy_link)
- [x] [자동 수정, 구간 피드백 IF1 위치](https://www.notion.so/I1-2038209b09f980ddbc80ee19760eddf0?source=copy_link)
- [x] [아직 답변이 나오지 않았는데 이대로 수정하기가 나타남
](https://www.notion.so/2098209b09f9802d8b64d5ebf763fd90?source=copy_link)
- [x] [내보내기 시 하이라이트, 밑줄까지 같이 내보내짐](https://www.notion.so/2088209b09f9805daad9cd4b5c132913?source=copy_link)
- [x] [구간 피드백이 한 줄로 표시됨](https://www.notion.so/2038209b09f980918f9ecb3838cfa0ba?source=copy_link)
- [x] [프롬프트, 메모 입력창에서 줄바꿈 기능 구현](https://www.notion.so/2048209b09f980528081fef67ca0bd30?source=copy_link)
- [x] [메모 탭을 한 번도 안 연 상태에서 메모 저장이 안 됨](https://www.notion.so/2068209b09f9803f8f08e133c92df29f?source=copy_link)
- [x] [AI 어시 IF1 에러핸들링](https://www.notion.so/AI-IF1-20c8209b09f980b3a770f2e7c1d0bf05?source=copy_link)

<br />

### 코드 관련
- 에디터에서 선택한(드래그한) 텍스트 영역 기준으로 ai-assistant 메뉴 위치를 계산하는 훅 구현
- prompt input > textarea로 변경에 따른 공통 PromptInput 컴포넌트 구현
  - @HaJaehyeong 재형님, 이 부분 공통 컴포넌트(PromptInput)으로 만들어 두었는데, 작품 플래너에 적용할 수 있는지 잘 몰라서 플래너쪽은 수정하지 않았습니다.
- useTextEditor hook에서 자동 수정, 수동 수정, 구간 피드백 관련 에러 핸들링
- 기타 코드 리팩토링

<br />

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
- 변경 사항 링크를 통해 노션 페이지에서 해결 된 스크린샷을 확인할 수 있습니다.

<br />

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->

<br />