### PR TITLE
[KAN-160] Fix: 메모 툴바, 에디터 원본 문구 선택 구간 이슈 수정

### DIFF
--- a/src/app/components/editor/ai-assistant-interface/menu/FeedbackOptionMenu.tsx
+++ b/src/app/components/editor/ai-assistant-interface/menu/FeedbackOptionMenu.tsx
@@ -50,6 +50,7 @@ export default function FeedbackOptionMenu({
               padding: '0.8rem 1.2rem',
               height: '100%',
               width: 50,
+              wordBreak: 'keep-all',
             }}
             onClick={onSubmitFeedback('ETC')}
           >

--- a/src/app/hooks/editor/useTextEditor.tsx
+++ b/src/app/hooks/editor/useTextEditor.tsx
@@ -150,7 +150,8 @@ export function useTextEditor(editor: Editor | null) {
     if (!selection) return
 
     // 선택한 원본 text 저장
-    const originPhrase = editor.getText().slice(selection?.from - 1, selection?.to)
+    // const originPhrase = editor.getText().slice(selection?.from, selection?.to) // 기존코드 참고용
+    const originPhrase = editor.state.doc.textBetween(selection?.from, selection?.to, ' ')
     setOriginalText(originPhrase)
 
     if (type === 'auto-modify' && originPhrase) {


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
<!-- 이 PR이 어떤 문제를 해결하거나 어떤 기능을 추가하는지 설명해주세요. -->
- [x] [메모 창을 벗어날 시 툴바가 다시 안 나타나고 메모 창만 나타남](https://www.notion.so/20f8209b09f98056b89bdaf50186a4c2?source=copy_link)
- [x] [AI 어시 사용 시 한 하이라이트가 사용 종료된 후에도 유지됨 QA 중 일부](https://www.notion.so/AI-2098209b09f980a79302dfe1829b3f67?source=copy_link)
- [x] [AI 어시 피드백 제출 버튼 UI 수정](https://www.notion.so/AI-UI-20c8209b09f980e38778c3b2808ea90b?source=copy_link)

<br />

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- JIRA-159

<br />

> ## 변경 사항
<!-- 이 PR에서 변경된 사항을 상세히 설명해주세요. -->
- [x] 툴바 메모 prompt 수정 (관련 [QA](https://www.notion.so/20f8209b09f98056b89bdaf50186a4c2?source=copy_link))
- [x] 원본 문구 저장시 실제 드래그한 부분보다 한칸 더 많이 드래그되는 이슈 해결 (관련 [QA](https://www.notion.so/AI-2098209b09f980a79302dfe1829b3f67?source=copy_link))
  - 해당 오류로인해 api호출 시 한칸 더 문구가 포함된 텍스트로 payload에 포함됨
  - 하이라이트 시에도 한칸 더 하이라이트 됨
  - 하이라이트 취소시에는 실제 드래그한 구간만큼 하이라이트가 취소되어 나머지 한칸에 대한 글자가 추가로 생기고 하이라이트됨  
- [x] 메모 툴바에서 사용하는 FillButton에 줄바꿈 하지 않는 속성 추가

<br />

> ## 스크린샷 (필요한 경우)
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요. -->
### 드래그 수정 전
![드래그 수정 전](https://github.com/user-attachments/assets/1bf17215-72a8-4849-b2e8-50b900591e25)

### 드래그 수정 후
![드래그 수정후](https://github.com/user-attachments/assets/64d4ec07-47bb-4bf5-a15a-48466bdabf63)

### 메모 툴바
![메모툴바](https://github.com/user-attachments/assets/e8129cd7-407e-43ba-9c4d-cc5839372f27)

<br />

> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
