### PR TITLE
KAN-164 Fix: QA 작품 플래너 버그 대응 2차

### DIFF
--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { PLANNER_CHARACTER_ITEMS } from 'constants/planner/plannerConstants'
 import { useAtom, useAtomValue } from 'jotai'
@@ -6,9 +6,11 @@ import { useFormContext, useWatch } from 'react-hook-form'
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io'
 import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
 import { PlannerTemplatesModeAtom } from 'store/plannerModeAtoms'
+import { ModalHandler } from 'types/common/modalRef'
 import { CharacterFormValues } from 'types/planner/plannerSynopsisFormValues'
 
 import FillButton from '@components/buttons/FillButton'
+import Modal from '@components/modal/Modal'
 import TextField from '@components/text-field/TextField'
 
 import { useCollapsed } from '@hooks/common/useCollapsed'
@@ -43,6 +45,7 @@ export default function PlannerCharacterFormList({
   const { control } = useFormContext()
   const [formValues, setFormValues] = useAtom(plannerCharacterByIdAtom(paramsId))
   const mode = useAtomValue(PlannerTemplatesModeAtom)
+  const modalRef = useRef<ModalHandler | null>(null)
 
   const getTextFieldName = (name: string) => {
     // NOTE(hajae): customFields는 배열이나, 디자인상 Character Fields에서는 하나의 필드를 사용 중
@@ -80,7 +83,7 @@ export default function PlannerCharacterFormList({
                 size="small"
                 variant="secondary"
                 type="button"
-                onClick={() => handleRemoveCharacter(arrayIndex)}
+                onClick={() => modalRef.current?.open()}
               >
                 삭제하기
               </FillButton>
@@ -134,6 +137,19 @@ export default function PlannerCharacterFormList({
           )}
         </div>
       )}
+      <Modal
+        ref={modalRef}
+        title="정말 삭제하시겠습니까? 이작업은 되돌릴 수 없습니다."
+        cancelText="취소하기"
+        confirmText="삭제하기"
+        onCancel={() => {
+          modalRef.current?.close()
+        }}
+        onConfirm={async () => {
+          modalRef.current?.close()
+          handleRemoveCharacter(arrayIndex)
+        }}
+      />
     </div>
   )
 }

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form-list/PlannerCharacterFormList.tsx
@@ -106,6 +106,7 @@ export default function PlannerCharacterFormList({
               <PlannerFieldWithButton
                 key={`planner-character-item-${index}`}
                 name={getTextFieldName(item.name)}
+                showConfirm={item.name === 'customFields'}
                 handleManualModification={handleManualModification(
                   getTextFieldName(item.name),
                   item.name,

--- a/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-character-form/PlannerCharacterForm.tsx
@@ -5,9 +5,10 @@ import { useParams } from 'next/navigation'
 import { useEffect } from 'react'
 
 import { NEW_PLANNER_CHARACTER } from 'constants/planner/plannerConstants'
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { useFormContext } from 'react-hook-form'
 import { plannerCharacterByIdAtom } from 'store/plannerAtoms'
+import { PlannerTemplatesModeAtom } from 'store/plannerModeAtoms'
 
 import FillButton from '@components/buttons/FillButton'
 
@@ -31,6 +32,7 @@ export default function PlannerCharacterForm({
 }: PlannerCharacterFormProps) {
   const params = useParams<{ id: string }>()
   const { setValue } = useFormContext()
+  const mode = useAtomValue(PlannerTemplatesModeAtom)
   const [formValues, setFormValues] = useAtom(plannerCharacterByIdAtom(params.id))
 
   const handleAddCharacter = () => {
@@ -51,9 +53,11 @@ export default function PlannerCharacterForm({
     <div className={cx('character-form')} id="heading3">
       <div className={cx('character-form__title')}>
         <span>등장 인물</span>
-        <FillButton size="small" variant="secondary" onClick={handleAddCharacter} type="button">
-          추가하기
-        </FillButton>
+        {mode === 'edit' && (
+          <FillButton size="small" variant="secondary" onClick={handleAddCharacter} type="button">
+            추가하기
+          </FillButton>
+        )}
       </div>
 
       {formValues.characters &&

--- a/src/app/(after-login)/planner/[id]/_components/planner-tabs/PlannerTabs.module.scss
+++ b/src/app/(after-login)/planner/[id]/_components/planner-tabs/PlannerTabs.module.scss
@@ -8,5 +8,7 @@
   align-items: center;
   justify-content: center;
 
+  width: 212px;
+
   z-index: 1;
 }

--- a/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
+++ b/src/app/(after-login)/planner/[id]/_components/planner-world-view-form/PlannerWorldViewForm.tsx
@@ -69,6 +69,7 @@ export default function PlannerWorldViewForm({
         <PlannerFieldWithButton
           key={field.id || index}
           name={`worldview.customFields[${index}]`}
+          showConfirm={true}
           onDelete={() => handleDeleteCustomField(index)}
         >
           <TextField

--- a/src/app/(after-login)/planner/[id]/page.module.scss
+++ b/src/app/(after-login)/planner/[id]/page.module.scss
@@ -9,6 +9,9 @@
 /* main */
 .main-section {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   padding-top: 12.4rem;
   height: 100dvh;


### PR DESCRIPTION
![header](https://capsule-render.vercel.app/api?type=waving&color=auto&section=header&text=FE%20PR&fontAlign=88)

> ## 설명
- 작품 플래너 UI 오류
    - 시놉시스, 아이디어노트 탭 `width`
- 작품 플래너 커스텀 항목 삭제 시 경고 메시지 안 뜸
    - 커스텀항목 및 등장인물 삭제 시 경고 팝업

> ## 관련 이슈
<!-- 이 PR과 관련된 이슈를 링크해주세요. (예: #123) -->
- close [#164](https://writelyforwriters.atlassian.net/browse/KAN-164)

> ## 변경 사항
- 작품 플래너 페이지 및 탭 스타일 수정
- 작품 플래너 커스텀 항목 및 등장인물 삭제, 등장인물 커스텀필드 삭제 시 확인 모달 표시

> ## 스크린샷 (필요한 경우)
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/3e818c9f-3cc2-4c78-9868-80427019b627" />


> ## 추가 정보
<!-- 기타 참고할 만한 정보를 적어주세요. -->
